### PR TITLE
Fix typo in docs

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -34,7 +34,7 @@ defmodule Req do
 
   ## Options
 
-    * `:header` - request headers, defaults to `[]`
+    * `:headers` - request headers, defaults to `[]`
 
     * `:body` - request body, defaults to `""`
 


### PR DESCRIPTION
Thought it was a strange API, and then wondered why the strange API didn't work. Turns out it was just a small typo in the docs 😄

Thanks for this library!