### PR TITLE
Add `:private` field to Response

### DIFF
--- a/lib/req/response.ex
+++ b/lib/req/response.ex
@@ -9,7 +9,30 @@ defmodule Req.Response do
     * `:headers` - the HTTP response headers
 
     * `:body` - the HTTP response body
+
+    * `:private` - a map reserved for libraries and frameworks to use.
+      Prefix the keys with the name of your project to avoid any future
+      conflicts. Only accepts `t:atom/0` keys.
   """
 
-  defstruct [:status, headers: [], body: ""]
+  defstruct [
+    :status,
+    headers: [],
+    body: "",
+    private: %{}
+  ]
+
+  @doc """
+  Gets the value for a specific private `key`.
+  """
+  def get_private(response, key, default \\ nil) when is_atom(key) do
+    Map.get(response.private, key, default)
+  end
+
+  @doc """
+  Assigns a private `key` to `value`.
+  """
+  def put_private(response, key, value) when is_atom(key) do
+    put_in(response.private[key], value)
+  end
 end


### PR DESCRIPTION
It was possible to annotate Requests with library-specific metadata using the :private field, however the same wasn't true for Responses. This means that it wasn't possible to return extra information to the caller.