### PR TITLE
`follow_redirects`: Don't send auth headers on redirect to different host

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Req is an HTTP client with a focus on ease of use and composability, built on to
 
   * Range requests (via [`put_range`](`Req.Steps.put_range/2`) step)
 
-  * Follows redirects (via [`follow_redirects`](`Req.Steps.follow_redirects/1`) step)
+  * Follows redirects (via [`follow_redirects`](`Req.Steps.follow_redirects/2`) step)
 
   * Retries on errors (via [`retry`](`Req.Steps.retry/2`) step)
 

--- a/lib/req/request.ex
+++ b/lib/req/request.ex
@@ -24,6 +24,9 @@ defmodule Req.Request do
 
     * `:error_steps` - the list of error steps
 
+    * `:location_trusted` - if `false`, authorization headers are not
+      sent to different hosts on redirects. Defaults to `false`.
+
     * `:private` - a map reserved for libraries and frameworks to use.
       Prefix the keys with the name of your project to avoid any future
       conflicts. Only accepts `t:atom/0` keys.
@@ -124,7 +127,8 @@ defmodule Req.Request do
     request_steps: [],
     response_steps: [],
     error_steps: [],
-    private: %{}
+    private: %{},
+    location_trusted: false
   ]
 
   @doc """
@@ -186,7 +190,8 @@ defmodule Req.Request do
       private: %{
         req_finch:
           {Keyword.get(options, :finch, Req.Finch), Keyword.get(options, :finch_options, [])}
-      }
+      },
+      location_trusted: Keyword.get(options, :location_trusted, false)
     }
   end
 

--- a/lib/req/request.ex
+++ b/lib/req/request.ex
@@ -24,9 +24,6 @@ defmodule Req.Request do
 
     * `:error_steps` - the list of error steps
 
-    * `:location_trusted` - if `false`, authorization headers are not
-      sent to different hosts on redirects. Defaults to `false`.
-
     * `:private` - a map reserved for libraries and frameworks to use.
       Prefix the keys with the name of your project to avoid any future
       conflicts. Only accepts `t:atom/0` keys.
@@ -190,8 +187,7 @@ defmodule Req.Request do
       private: %{
         req_finch:
           {Keyword.get(options, :finch, Req.Finch), Keyword.get(options, :finch_options, [])}
-      },
-      location_trusted: Keyword.get(options, :location_trusted, false)
+      }
     }
   end
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -36,7 +36,7 @@ defmodule Req.Steps do
     * [`&retry(&1, options[:retry])`](`retry/2`) (if `options[:retry]` is set to
       an atom true or a options keywords list)
 
-    * `follow_redirects/1`
+    * [`&follow_redirects(&1, options[:follow_redirects])`](`follow_redirects/2`)
 
     * `decompress/1`
 
@@ -67,6 +67,9 @@ defmodule Req.Steps do
 
     * `:steps` - if set, runs the `run_steps/2` step with the given steps
 
+    * `:follow_redirects` - if set, runs the `follow_redirect/2` step with the given list
+       of options
+
   """
   @doc step: :request
   def put_default_steps(request, options \\ []) do
@@ -91,7 +94,7 @@ defmodule Req.Steps do
 
     response_steps =
       maybe_steps(retry, [{Req.Steps, :retry, [retry]}]) ++
-        [{Req.Steps, :follow_redirects, []}] ++
+        [{Req.Steps, :follow_redirects, [options[:follow_redirects]]}] ++
         maybe_steps(not raw?, [
           {Req.Steps, :decompress, []},
           {Req.Steps, :decode_body, []}
@@ -621,6 +624,12 @@ defmodule Req.Steps do
   @doc """
   Follows redirects.
 
+  ## Options
+
+    * `:location_trusted` - by default, authorization credentials are only sent
+      on redirects to the same host. If `:location_trusted` is set to `true`, credentials
+      will be sent to any host.
+
   ## Examples
 
       iex> Req.get!("http://api.github.com").status
@@ -629,20 +638,26 @@ defmodule Req.Steps do
 
   """
   @doc step: :response
-  def follow_redirects({request, %{status: status} = response}) when status in 301..302 do
+  def follow_redirects(request, options \\ [])
+
+  def follow_redirects({request, %{status: status} = response}, options)
+      when status in 301..302 do
     {_, location} = List.keyfind(response.headers, "location", 0)
     Logger.debug(["Req.follow_redirects/2: Redirecting to ", location])
 
+    location_trusted = options[:location_trusted]
+    location_url = URI.parse(location)
+
     request =
       request
-      |> remove_credentials_if_untrusted(location)
-      |> put_redirect_location(location)
+      |> remove_credentials_if_untrusted(location_trusted, location_url)
+      |> put_redirect_location(location_url)
 
     {_, result} = Req.Request.run(request)
     {Req.Request.halt(request), result}
   end
 
-  def follow_redirects(other) do
+  def follow_redirects(other, _) do
     other
   end
 
@@ -826,20 +841,18 @@ defmodule Req.Steps do
     acc
   end
 
-  defp put_redirect_location(request, location) do
-    if String.starts_with?(location, "/") do
-      url = URI.parse(location)
-      update_in(request.url, &%{&1 | path: url.path, query: url.query})
+  defp put_redirect_location(request, location_url) do
+    if location_url.host do
+      put_in(request.url, location_url)
     else
-      url = URI.parse(location)
-      put_in(request.url, url)
+      update_in(request.url, &%{&1 | path: location_url.path, query: location_url.query})
     end
   end
 
-  defp remove_credentials_if_untrusted(%{location_trusted: true} = request, _), do: request
+  defp remove_credentials_if_untrusted(request, true, _), do: request
 
-  defp remove_credentials_if_untrusted(%{url: url} = request, location) do
-    if URI.parse(location).host == url.host do
+  defp remove_credentials_if_untrusted(request, _, location_url) do
+    if location_url.host == request.url.host do
       request
     else
       remove_credentials(request)
@@ -850,6 +863,6 @@ defmodule Req.Steps do
     headers = List.keydelete(request.headers, "authorization", 0)
     request_steps = Enum.reject(request.request_steps, fn {_, step, _} -> step == :auth end)
 
-    struct(request, headers: headers, request_steps: request_steps)
+    %{request | headers: headers, request_steps: request_steps}
   end
 end


### PR DESCRIPTION
Closes #13.