### PR TITLE
add :adapter option

### DIFF
--- a/lib/req/request.ex
+++ b/lib/req/request.ex
@@ -132,7 +132,7 @@ defmodule Req.Request do
   Sets the request adapter.
 
   Adapter is a request step that is making the actual HTTP request. See
-  `Req.Request.build/3` for more information.
+  `build/3` for more information.
 
   """
   def put_adapter(request, adapter) do

--- a/lib/req/request.ex
+++ b/lib/req/request.ex
@@ -118,7 +118,7 @@ defmodule Req.Request do
     :url,
     headers: [],
     body: "",
-    adapter: {Req.Steps, :run_finch, []},
+    adapter: nil,
     unix_socket: nil,
     halted: false,
     request_steps: [],
@@ -131,10 +131,9 @@ defmodule Req.Request do
   @doc """
   Sets the request adapter.
 
-  Adapter is a request step that is making the actual HTTP request. It is
-  automatically executed as the very last step in the request pipeline.
+  Adapter is a request step that is making the actual HTTP request. See
+  `Req.Request.build/3` for more information.
 
-  The default adapter is using `Finch`.
   """
   def put_adapter(request, adapter) do
     %{request | adapter: adapter}
@@ -170,6 +169,10 @@ defmodule Req.Request do
 
     * `:body` - request body, defaults to `""`
 
+    * `:adapter` - adapter to use to make the actual HTTP request. Adapters are functions
+    specified like any other request step, but the adapter function is the last step
+    executed in the request pipeline. Defaults to calling `Req.Steps.run_finch/1`.
+
     * `:finch` - Finch pool to use, defaults to `Req.Finch` which is automatically started
       by the application. See `Finch` module documentation for more information on starting pools.
 
@@ -184,6 +187,7 @@ defmodule Req.Request do
       headers: Keyword.get(options, :headers, []),
       body: Keyword.get(options, :body, ""),
       unix_socket: Keyword.get(options, :unix_socket),
+      adapter: Keyword.get(options, :adapter, {Req.Steps, :run_finch, []}),
       private: %{
         req_finch:
           {Keyword.get(options, :finch, Req.Finch), Keyword.get(options, :finch_options, [])}

--- a/lib/req/request.ex
+++ b/lib/req/request.ex
@@ -118,7 +118,7 @@ defmodule Req.Request do
     :url,
     headers: [],
     body: "",
-    adapter: nil,
+    adapter: {Req.Steps, :run_finch, []},
     unix_socket: nil,
     halted: false,
     request_steps: [],

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -452,7 +452,7 @@ defmodule Req.Steps do
   @doc """
   Runs the request using `Finch`.
 
-  This is the default adapter. See `Req.Request.put_adapter/2` for more information.
+  This is the default adapter. See `Req.Request.build/3` for more information.
   """
   @doc step: :request
   def run_finch(request) do

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -440,7 +440,7 @@ defmodule Req.StepsTest do
 
     assert ExUnit.CaptureLog.capture_log(fn ->
              assert Req.get!("http://original",
-                      steps: [adapter],
+                      adapter: adapter,
                       auth: {"authorization", "credentials"},
                       follow_redirects: [location_trusted: true]
                     ).status == 200
@@ -476,7 +476,7 @@ defmodule Req.StepsTest do
 
     assert ExUnit.CaptureLog.capture_log(fn ->
              assert Req.get!("http://original",
-                      steps: [adapter],
+                      adapter: adapter,
                       auth: {"authorization", "credentials"}
                     ).status == 200
            end) =~ "[debug] Req.follow_redirects/2: Redirecting to http://untrusted"


### PR DESCRIPTION
Closes #66.

Note that the option is added to `Req.build/3`, for a few reasons:

- the adapter runs like a request step, but it is really a required attribute of the request, unlike any other steps
- because the adapter is required and required to run last, it seemed confusing to make changes to something that is required as part of the process of adding defaults. It feels more natural to modify the request defaults when building the request.

I did not add new tests. I did update the two tests that use a custom adapter to add it using this option. Let me know if a separate test is desirable.