### PR TITLE
Replace load_netrc with auth: :netrc | {:netrc, path}

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ Req is an HTTP client with a focus on ease of use and composability, built on to
 
   * Encode params as query string (via [`put_params`](`Req.Steps.put_params/2`) step)
 
-  * Basic authentication (via [`auth`](`Req.Steps.auth/2`) step)
-
-  * `.netrc` file support (via [`load_netrc`](`Req.Steps.load_netrc/2`) step)
+  * Basic, bearer and `.netrc` authentication (via [`auth`](`Req.Steps.auth/2`) step)
 
   * Range requests (via [`put_range`](`Req.Steps.put_range/2`) step)
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -195,15 +195,18 @@ defmodule Req.Steps do
   end
 
   defp load_netrc(path) do
-    case File.read!(path) do
-      "" ->
+    case File.read(path) do
+      {:ok, ""} ->
         raise ".netrc file is empty."
 
-      contents ->
+      {:ok, contents} ->
         contents
         |> String.trim()
         |> String.split()
         |> parse_netrc()
+
+      {:error, reason} ->
+        raise "Error reading .netrc file: #{:file.format_error(reason)}"
     end
   end
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -155,11 +155,11 @@ defmodule Req.Steps do
       iex> Req.get!("https://httpbin.org/bearer", auth: {:bearer, "foo"}).status
       200
 
-      iex> System.put_env("NETRC", "/path/in/environment/variable")
+      iex> System.put_env("NETRC", "./my_netrc")
       iex> Req.get!("https://httpbin.org/basic-auth/foo/bar", auth: :netrc).status
       200
 
-      iex> Req.get!("https://httpbin.org/basic-auth/foo/bar", auth: {:netrc, "custom/.netrc"}).status
+      iex> Req.get!("https://httpbin.org/basic-auth/foo/bar", auth: {:netrc, "./my_netrc"}).status
       200
   """
   @doc step: :request
@@ -175,8 +175,7 @@ defmodule Req.Steps do
   end
 
   def auth(request, :netrc) do
-    directory = System.get_env("NETRC", System.user_home!())
-    path = Path.join(directory, ".netrc")
+    path = System.get_env("NETRC") || Path.join(System.user_home!(), ".netrc")
     authenticate_with_netrc(request, path)
   end
 
@@ -197,7 +196,7 @@ defmodule Req.Steps do
   defp load_netrc(path) do
     case File.read(path) do
       {:ok, ""} ->
-        raise ".netrc file is empty."
+        raise ".netrc file is empty"
 
       {:ok, contents} ->
         contents
@@ -206,7 +205,7 @@ defmodule Req.Steps do
         |> parse_netrc()
 
       {:error, reason} ->
-        raise "Error reading .netrc file: #{:file.format_error(reason)}"
+        raise "error reading .netrc file: #{:file.format_error(reason)}"
     end
   end
 
@@ -219,7 +218,7 @@ defmodule Req.Steps do
     parse_netrc(tail, acc)
   end
 
-  defp parse_netrc(_, _), do: raise("Error parsing .netrc.")
+  defp parse_netrc(_, _), do: raise("error parsing .netrc file")
 
   @user_agent "req/#{Mix.Project.config()[:version]}"
 

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -51,6 +51,99 @@ defmodule Req.StepsTest do
     assert Req.get!(c.url <> "/auth", auth: {:bearer, "valid_token"}).status == 200
   end
 
+  @tag :tmp_dir
+  test "auth/2: :netrc", c do
+    Bypass.expect(c.bypass, "GET", "/auth", fn conn ->
+      expected = "Basic " <> Base.encode64("foo:bar")
+
+      case Plug.Conn.get_req_header(conn, "authorization") do
+        [^expected] ->
+          Plug.Conn.send_resp(conn, 200, "ok")
+
+        _ ->
+          Plug.Conn.send_resp(conn, 401, "unauthorized")
+      end
+    end)
+
+    assert Req.get!(c.url <> "/auth").status == 401
+
+    File.write!("#{c.tmp_dir}/.netrc", """
+    machine localhost
+    login foo
+    password bar
+    """)
+
+    old_netrc = System.get_env("NETRC")
+    System.put_env("NETRC", c.tmp_dir)
+    assert Req.get!(c.url <> "/auth", auth: :netrc).status == 200
+
+    File.write!("#{c.tmp_dir}/.netrc", """
+    machine otherhost
+    login meat
+    password potatoes
+    machine localhost login foo password bar
+    """)
+
+    assert Req.get!(c.url <> "/auth", auth: :netrc).status == 200
+
+    File.write!("#{c.tmp_dir}/.netrc", """
+    machine localhost
+         login foo
+         password bar
+    """)
+
+    assert Req.get!(c.url <> "/auth", auth: :netrc).status == 200
+
+    if old_netrc, do: System.put_env("NETRC", old_netrc), else: System.delete_env("NETRC")
+  end
+
+  @tag :tmp_dir
+  test "auth/2: {:netrc, path}", c do
+    Bypass.expect(c.bypass, "GET", "/auth", fn conn ->
+      expected = "Basic " <> Base.encode64("foo:bar")
+
+      case Plug.Conn.get_req_header(conn, "authorization") do
+        [^expected] ->
+          Plug.Conn.send_resp(conn, 200, "ok")
+
+        _ ->
+          Plug.Conn.send_resp(conn, 401, "unauthorized")
+      end
+    end)
+
+    assert Req.get!(c.url <> "/auth", auth: :netrc).status == 401
+
+    File.write!("#{c.tmp_dir}/custom_netrc", """
+    machine localhost
+    login foo
+    password bar
+    """)
+
+    assert Req.get!(c.url <> "/auth", auth: {:netrc, c.tmp_dir <> "/custom_netrc"}).status == 200
+
+    File.write!("#{c.tmp_dir}/wrong_netrc", """
+    machine localhost
+    login bad
+    password bad
+    """)
+
+    assert Req.get!(c.url <> "/auth", auth: {:netrc, "#{c.tmp_dir}/wrong_netrc"}).status == 401
+
+    File.write!("#{c.tmp_dir}/empty_netrc", "")
+
+    assert_raise RuntimeError, ".netrc file is empty.", fn ->
+      Req.get!(c.url <> "/auth", auth: {:netrc, "#{c.tmp_dir}/empty_netrc"})
+    end
+
+    File.write!("#{c.tmp_dir}/bad_netrc", """
+    bad
+    """)
+
+    assert_raise RuntimeError, "Error parsing .netrc.", fn ->
+      Req.get!(c.url <> "/auth", auth: {:netrc, "#{c.tmp_dir}/bad_netrc"})
+    end
+  end
+
   test "encode_headers/1", c do
     pid = self()
 
@@ -81,50 +174,6 @@ defmodule Req.StepsTest do
     assert_received {:params, %{"foo" => "bar"}}
   after
     Application.put_env(:req, :default_options, [])
-  end
-
-  @tag :tmp_dir
-  test "load_netrc/2", c do
-    Bypass.expect(c.bypass, "GET", "/auth", fn conn ->
-      expected = "Basic " <> Base.encode64("foo:bar")
-
-      case Plug.Conn.get_req_header(conn, "authorization") do
-        [^expected] ->
-          Plug.Conn.send_resp(conn, 200, "ok")
-
-        _ ->
-          Plug.Conn.send_resp(conn, 401, "unauthorized")
-      end
-    end)
-
-    assert Req.get!(c.url <> "/auth").status == 401
-
-    File.write!("#{c.tmp_dir}/empty_netrc", "")
-    assert Req.get!(c.url <> "/auth", netrc: "#{c.tmp_dir}/empty_netrc").status == 401
-
-    File.write!("#{c.tmp_dir}/wrong_netrc", """
-    machine localhost
-    username bad
-    password bad
-    """)
-
-    assert Req.get!(c.url <> "/auth", netrc: "#{c.tmp_dir}/wrong_netrc").status == 401
-
-    File.write!("#{c.tmp_dir}/correct_netrc", """
-    machine localhost
-    username foo
-    password bar
-    """)
-
-    assert Req.get!(c.url <> "/auth", netrc: "#{c.tmp_dir}/correct_netrc").status == 200
-
-    File.write!("#{c.tmp_dir}/bad_netrc", """
-    bad
-    """)
-
-    assert_raise RuntimeError, "parse error: \"bad\"", fn ->
-      Req.get!(c.url <> "/auth", netrc: "#{c.tmp_dir}/bad_netrc")
-    end
   end
 
   test "default_headers/1", c do

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -111,7 +111,15 @@ defmodule Req.StepsTest do
       end
     end)
 
-    assert Req.get!(c.url <> "/auth", auth: :netrc).status == 401
+    directory = System.get_env("NETRC", System.user_home!())
+
+    if File.exists?(Path.join(directory, ".netrc")) do
+      assert Req.get!(c.url <> "/auth", auth: :netrc).status == 401
+    else
+      assert_raise RuntimeError, "Error reading .netrc file: no such file or directory", fn ->
+        Req.get!(c.url <> "/auth", auth: :netrc)
+      end
+    end
 
     File.write!("#{c.tmp_dir}/custom_netrc", """
     machine localhost


### PR DESCRIPTION
Closes #52 and closes #60. This version gets rid of the `load_rtc` step. It uses similar logic under the hood, with the following changes:

1. Look for `login` instead of `username`
2. Parse records stored in `.netrc` as a single line or as multiple lines