### PR TITLE
add (first) httpbin.org tests

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -155,11 +155,11 @@ defmodule Req.Steps do
       iex> Req.get!("https://httpbin.org/bearer", auth: {:bearer, "foo"}).status
       200
 
-      iex> System.put_env("NETRC", "./my_netrc")
+      iex> System.put_env("NETRC", "./test/my_netrc")
       iex> Req.get!("https://httpbin.org/basic-auth/foo/bar", auth: :netrc).status
       200
 
-      iex> Req.get!("https://httpbin.org/basic-auth/foo/bar", auth: {:netrc, "./my_netrc"}).status
+      iex> Req.get!("https://httpbin.org/basic-auth/foo/bar", auth: {:netrc, "./test/my_netrc"}).status
       200
   """
   @doc step: :request
@@ -350,13 +350,24 @@ defmodule Req.Steps do
 
   ## Examples
 
-      iex> Req.get!("https://repo.hex.pm/builds/elixir/builds.txt", range: 0..67)
-      %Req.Response{
-        status: 206,
-        headers: [{"content-range", "bytes 0-67/45400"}, ...],
-        body: "master df65074a8143cebec810dfb91cafa43f19dcdbaf 2021-04-23T15:36:18Z"
-      }
-
+      iex> response = Req.get!("https://httpbin.org/range/100", range: 0..67)
+      iex> response.status
+      206
+      iex> response.body
+      "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnop"
+      iex> [_ | headers] = response.headers  # cut {"date", ...}
+      ...> headers
+      [
+        {"content-type", "application/octet-stream"},
+        {"content-length", "68"},
+        {"connection", "keep-alive"},
+        {"server", "gunicorn/19.9.0"},
+        {"etag", "range100"},
+        {"accept-ranges", "bytes"},
+        {"content-range", "bytes 0-67/100"},
+        {"access-control-allow-origin", "*"},
+        {"access-control-allow-credentials", "true"}
+      ]
   """
   @doc step: :request
   def put_range(request, range)
@@ -384,7 +395,7 @@ defmodule Req.Steps do
 
   ## Examples
 
-      iex> url = "https://hexdocs.pm/elixir/Kernel.html"
+      iex> url = "https://httpbin.org/html"
       iex> response1 = Req.get!(url, cache: true)
       iex> response2 = Req.get!(url, cache: true)
       iex> response1 == response2
@@ -497,18 +508,10 @@ defmodule Req.Steps do
   ## Examples
 
       iex> response = Req.get!("https://httpbin.org/gzip")
-      iex> response.headers
-      [
-        {"content-encoding", "gzip"},
-        {"content-type", "application/json"},
-        ...
-      ]
-      iex> response.body
-      %{
-        "gzipped" => true,
-        ...
-      }
-
+      iex> response.headers |> Enum.member?({"content-encoding", "gzip"})
+      true
+      iex> response.body["gzipped"]
+      true
   """
   @doc step: :response
   def decompress(request_response)
@@ -557,13 +560,13 @@ defmodule Req.Steps do
 
   ## Examples
 
-      iex> Req.get!("https://hex.pm/api/packages/finch").body["meta"]
-      %{
-        "description" => "An HTTP client focused on performance.",
-        "licenses" => ["MIT"],
-        "links" => %{"GitHub" => "https://github.com/keathley/finch"},
-        ...
-      }
+      iex> response = Req.get!("https://httpbin.org/gzip")
+      ...> response.body["gzipped"]
+      true
+
+      iex> response = Req.get!("https://httpbin.org/json")
+      ...> response.body["slideshow"]["title"]
+      "Sample Slide Show"
 
   """
   @doc step: :response

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -350,24 +350,13 @@ defmodule Req.Steps do
 
   ## Examples
 
-      iex> response = Req.get!("https://httpbin.org/range/100", range: 0..67)
+      iex> response = Req.get!("https://httpbin.org/range/100", range: 0..3)
       iex> response.status
       206
       iex> response.body
-      "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnop"
-      iex> [_ | headers] = response.headers  # cut {"date", ...}
-      ...> headers
-      [
-        {"content-type", "application/octet-stream"},
-        {"content-length", "68"},
-        {"connection", "keep-alive"},
-        {"server", "gunicorn/19.9.0"},
-        {"etag", "range100"},
-        {"accept-ranges", "bytes"},
-        {"content-range", "bytes 0-67/100"},
-        {"access-control-allow-origin", "*"},
-        {"access-control-allow-credentials", "true"}
-      ]
+      "abcd"
+      iex> List.keyfind(response.headers, "content-range", 0)
+      {"content-range", "bytes 0-3/100"}
   """
   @doc step: :request
   def put_range(request, range)

--- a/test/httpbin_test.exs
+++ b/test/httpbin_test.exs
@@ -1,0 +1,19 @@
+defmodule Req.HttpbinTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :httpbin
+
+  doctest Req.Steps,
+    only: [
+      auth: 2,
+      put_base_url: 2,
+      encode_headers: 1,
+      encode_body: 1,
+      put_params: 2,
+      put_range: 2,
+      # run_steps: 2,  #!TODO: make `run_steps/2` testabable
+      put_if_modified_since: 2,
+      decompress: 1,
+      decode_body: 1
+    ]
+end

--- a/test/my_netrc
+++ b/test/my_netrc
@@ -1,0 +1,7 @@
+machine localhost
+    login foo
+    password bar
+
+machine httpbin.org
+    login foo
+    password bar

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,5 @@
+unless System.get_env("CI") do
+  ExUnit.configure(exclude: :httpbin)
+end
+
 ExUnit.start()


### PR DESCRIPTION
I thought it might be beneficial to be able to test the library against https://httpbin.org. As an added benefit this enables us to use doctests.

For now I implemented the tests for the
 

- [x] high-level APIs
- [x] auth steps
- [ ] request steps
  - [x] `put_base_url/2`
    - [x] `encode_headers/1`
    - [x] `encode_body/1`
    - [x] `put_params/2`
    - [x] `put_range/2`
    - [x] `put_if_modified_since/2`
    - [ ] `run_steps/2`
- [ ] response steps
  - [x]  `decompress/1`
  - [ ]  `decode_body/1`
- [ ] error steps 

To not interfere with the existing tests and not depend on an internet connection (and a third-party service) I put those tests in an extra `test_httpbin` directory. To run those test just use

```
mix test test_httpbin
```

