### PR TITLE
New API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ Req is an HTTP client with a focus on ease of use and composability, built on to
   * Automatic body encoding and decoding (via [`encode_body`](`Req.Steps.encode_body/1`)
     and [`decode_body`](`Req.Steps.decode_body/1`) steps)
 
-  * Encode params as query string (via [`put_params`](`Req.Steps.put_params/2`) step)
+  * Encode params as query string (via [`put_params`](`Req.Steps.put_params/1`) step)
 
-  * Basic, bearer and `.netrc` authentication (via [`auth`](`Req.Steps.auth/2`) step)
+  * Basic, bearer and `.netrc` authentication (via [`auth`](`Req.Steps.auth/1`) step)
 
-  * Range requests (via [`put_range`](`Req.Steps.put_range/2`) step)
+  * Range requests (via [`put_range`](`Req.Steps.put_range/1`) step)
 
-  * Follows redirects (via [`follow_redirects`](`Req.Steps.follow_redirects/2`) step)
+  * Follows redirects (via [`follow_redirects`](`Req.Steps.follow_redirects/1`) step)
 
-  * Retries on errors (via [`retry`](`Req.Steps.retry/2`) step)
+  * Retries on errors (via [`retry`](`Req.Steps.retry/1`) step)
 
-  * Basic HTTP caching (via [`cache`](`Req.Steps.put_if_modified_since/2`) step)
+  * Basic HTTP caching (via [`cache`](`Req.Steps.put_if_modified_since/1`) step)
 
-  * Setting base URL (via [`put_base_url`](`Req.Steps.put_base_url/2`) step)
+  * Setting base URL (via [`put_base_url`](`Req.Steps.put_base_url/1`) step)
 
 ## Usage
 
@@ -37,22 +37,30 @@ The easiest way to use Req is with [`Mix.install/2`](https://hexdocs.pm/mix/Mix.
 
 ```elixir
 Mix.install([
-  {:req, "~> 0.2.0"}
+  {:req, "~> 0.3.0"}
 ])
 
 Req.get!("https://api.github.com/repos/elixir-lang/elixir").body["description"]
 #=> "Elixir is a dynamic, functional language designed for building scalable and maintainable applications"
 ```
 
-If you want to use Req in a Mix project, you can add the above
-dependency to your `mix.exs`.
+If you want to use Req in a Mix project, you can add the above dependency to your `mix.exs`.
 
-Example POST request:
+If you are planning to make several similar requests, you can build up a request struct with
+desired common options and re-use it:
 
 ```elixir
-Req.post!("https://httpbin.org/post", {:form, comments: "hello!"}).body["form"]
-#=> %{"comments" => "hello!"}
+req = Req.new(base_url: "https://api.github.com")
+
+Req.get!(req, url: "/repos/sneako/finch").body["description"]
+#=> "Elixir HTTP client, focused on performance"
+
+Req.get!(req, url: "/repos/elixir-mint/mint").body["description"]
+#=> "Functional HTTP client for Elixir with support for HTTP/1 and HTTP/2."
 ```
+
+See [`Req.request/1`](https://hexdocs.pm/req/Req.html#request/1) for more information on available
+options.
 
 ## Low-level API
 
@@ -75,12 +83,22 @@ Req.get!("https://api.github.com/repos/elixir-lang/elixir")
 is equivalent to this composition of lower-level API functions and steps:
 
 ```elixir
-Req.Request.build(:get, "https://api.github.com/repos/elixir-lang/elixir")
-|> Req.Steps.put_default_steps()
+Req.Request.new(method: :get, url: "https://api.github.com/repos/elixir-lang/elixir")
+|> Req.Request.append_request_steps([
+  &Req.Steps.encode_headers/1,
+  &Req.Steps.put_default_headers/1,
+  # ...
+])
+|> Req.Request.append_response_steps([
+  &Req.Steps.retry/1,
+  &Req.Steps.follow_redirects/1,
+  # ...
+|> Req.Request.append_error_steps([
+  &Req.Steps.retry/1,
+  # ...
+])
 |> Req.Request.run!()
 ```
-
-(See `Req.Request.build/3`, `Req.Steps.put_default_steps/2`, and `Req.Request.run!/1` for more information.)
 
 We can also build more complex flows like returning a response from a request step
 or an error from a response step. See `Req.Request` documentation for more information.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Req is an HTTP client with a focus on ease of use and composability, built on to
 
 ## Features
 
-  * A easy to use high-level API: `Req.request/1`, `Req.get!/2`, `Req.post!/2`, etc.
+  * An easy to use high-level API: `Req`, `Req.request/1`, `Req.get!/2`, `Req.post!/2`, etc.
 
   * Extensibility via request, response, and error steps.
 
@@ -64,9 +64,13 @@ Req.get!(req, url: "/repos/elixir-mint/mint").body["description"]
 See [`Req.request/1`](https://hexdocs.pm/req/Req.html#request/1) for more information on available
 options.
 
-## Low-level API
+## How Req Works
 
-Under the hood, Req works by passing a [`%Req.Request{}`](`Req.Request`) struct through a series of steps.
+Virtually all of Req's functionality is broken down into individual pieces - steps. Req works by
+running the request struct through these steps. You can easily reuse or rearrange built-in steps
+or write new ones.
+
+There are three types of steps: request, response, and error.
 
 Request steps are used to refine the data that will be sent to the server.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Req is an HTTP client with a focus on ease of use and composability, built on to
 
 ## Features
 
-  * Extensibility via request, response, and error steps
+  * A easy to use high-level API: `Req.request/1`, `Req.get!/2`, `Req.post!/2`, etc.
+
+  * Extensibility via request, response, and error steps.
 
   * Automatic body decompression (via [`decompress`](`Req.Steps.decompress/1`) step)
 
@@ -19,7 +21,7 @@ Req is an HTTP client with a focus on ease of use and composability, built on to
 
   * Encode params as query string (via [`put_params`](`Req.Steps.put_params/1`) step)
 
-  * Basic, bearer and `.netrc` authentication (via [`auth`](`Req.Steps.auth/1`) step)
+  * Basic, bearer, and `.netrc` authentication (via [`auth`](`Req.Steps.auth/1`) step)
 
   * Range requests (via [`put_range`](`Req.Steps.put_range/1`) step)
 

--- a/lib/req.ex
+++ b/lib/req.ex
@@ -334,15 +334,15 @@ defmodule Req do
   def request(request, options) do
     options = Keyword.merge(default_options(), options)
 
-      {request_options, options} = Keyword.split(options, [:method, :url, :headers, :body])
+    {request_options, options} = Keyword.split(options, [:method, :url, :headers, :body])
 
-      request =
-        Map.merge(request, Map.new(request_options), fn
-            :url, _, url -> URI.parse(url)
-            # TODO: merge headers
-            :headers, _, headers -> headers
-            _, _, value -> value
-        end)
+    request =
+      Map.merge(request, Map.new(request_options), fn
+        :url, _, url -> URI.parse(url)
+        # TODO: merge headers
+        :headers, _, headers -> headers
+        _, _, value -> value
+      end)
 
     request = update_in(request.options, &Map.merge(&1, Map.new(options)))
     Req.Request.run(request)

--- a/lib/req.ex
+++ b/lib/req.ex
@@ -10,46 +10,176 @@ defmodule Req do
 
   @type method() :: :get | :post | :put | :delete
 
+  @default_options %{
+    # request steps
+    auth: nil,
+    base_url: nil,
+    cache: nil,
+    cache_dir: nil,
+    params: [],
+    range: nil,
+    finch: Req.Finch,
+    pool_timeout: 5000,
+    receive_timeout: 15000,
+
+    # response steps
+    follow_redirects: true,
+    location_trusted: false,
+    raw: false,
+
+    # error steps
+    max_retries: 2,
+    retry: true,
+    retry_delay: 2000
+  }
+
+  @doc """
+  Returns a new request struct with default steps.
+
+  See `request/1` for a list of available options.
+  """
+  @spec new(options :: keyword()) :: Req.Request.t()
+  def new(options \\ []) do
+    {adapter, options} = Keyword.pop(options, :adapter, &Req.Steps.run_finch/1)
+    {method, options} = Keyword.pop(options, :method, :get)
+    {url, options} = Keyword.pop(options, :url, nil)
+    {headers, options} = Keyword.pop(options, :headers, [])
+    {body, options} = Keyword.pop(options, :body, "")
+    options = Map.merge(@default_options, Map.new(options))
+
+    %Req.Request{
+      adapter: adapter,
+      method: method,
+      url: url && URI.parse(url),
+      headers: headers,
+      body: body,
+      options: options,
+      request_steps: [
+        &Req.Steps.encode_headers/1,
+        &Req.Steps.put_default_headers/1,
+        &Req.Steps.encode_body/1,
+        &Req.Steps.put_base_url/1,
+        &Req.Steps.auth/1,
+        &Req.Steps.put_params/1,
+        &Req.Steps.put_range/1,
+        &Req.Steps.put_if_modified_since/1
+      ],
+      response_steps: [
+        &Req.Steps.retry/1,
+        &Req.Steps.follow_redirects/1,
+        &Req.Steps.decompress/1,
+        &Req.Steps.decode_body/1
+      ],
+      error_steps: [
+        &Req.Steps.retry/1
+      ]
+    }
+  end
+
   @doc """
   Makes a GET request.
 
-  See `request/3` for a list of supported options.
+  See `request/1` for a list of supported options.
+
+  ## Examples
+
+      iex> Req.get!("https://api.github.com/repos/elixir-lang/elixir").body["description"]
+      "Elixir is a dynamic, functional language designed for building scalable and maintainable applications"
+
   """
-  @spec get!(url(), keyword()) :: Req.Response.t()
-  def get!(url, options \\ []) do
-    request!(:get, url, options)
+  @spec get!(url() | Req.Request.t(), options :: keyword()) :: Req.Response.t()
+  def get!(url_or_request, options \\ [])
+
+  def get!(%Req.Request{} = request, options) do
+    request!(%{request | method: :get}, options)
+  end
+
+  def get!(url, options) do
+    request!([method: :get, url: URI.parse(url)] ++ options)
   end
 
   @doc """
   Makes a POST request.
 
-  See `request/3` for a list of supported options.
+  See `request/1` for a list of supported options.
+
+  ## Examples
+
+      iex> Req.post!("https://httpbin.org/post", body: {:form, foo: "hello!"}).body["form"]
+      #=> %{"comments" => "hello!"}
+
   """
-  @spec post!(url(), body :: term(), keyword()) :: Req.Response.t()
-  def post!(url, body, options \\ []) do
-    options = Keyword.put(options, :body, body)
-    request!(:post, url, options)
+  @spec post!(url() | Req.Request.t(), options :: keyword()) :: Req.Response.t()
+  def post!(url_or_request, options \\ [])
+
+  def post!(%Req.Request{} = request, options) do
+    request!(%{request | method: :post}, options)
+  end
+
+  def post!(url, options) do
+    if Keyword.keyword?(options) do
+      request!([method: :post, url: URI.parse(url)] ++ options)
+    else
+      IO.warn("Req.post!(url, body) is deprecated in favour of Req.post!(url, body: body)")
+      request!(method: :post, url: URI.parse(url), body: options)
+    end
+  end
+
+  @doc false
+  def post!(url, body, options) do
+    IO.warn(
+      "Req.post!(url, body, options) is deprecated in favour of " <>
+        "Req.post!(url, [body: body] ++ options)"
+    )
+
+    request!([method: :post, url: URI.parse(url), body: body] ++ options)
   end
 
   @doc """
   Makes a PUT request.
 
-  See `request/3` for a list of supported options.
+  See `request/1` for a list of supported options.
+
+  ## Examples
+
+      iex> Req.put!("https://httpbin.org/anything", body: "the body").body |> Map.take(["data", "method"])
+      %{"data" => "the body", "method" => "PUT"}
+
   """
-  @spec put!(url(), body :: term(), keyword()) :: Req.Response.t()
-  def put!(url, body, options \\ []) do
-    options = Keyword.put(options, :body, body)
-    request!(:put, url, options)
+  @spec put!(url() | Req.Request.t(), options :: keyword()) :: Req.Response.t()
+  def put!(url_or_request, options \\ [])
+
+  def put!(%Req.Request{} = request, options) do
+    request!(%{request | method: :put}, options)
+  end
+
+  def put!(url, options) do
+    if Keyword.keyword?(options) do
+      request!([method: :put, url: URI.parse(url)] ++ options)
+    else
+      IO.warn("Req.put!(url, body) is deprecated in favour of Req.put!(url, body: body)")
+      request!(url: URI.parse(url), body: options)
+    end
+  end
+
+  @doc false
+  def put!(%URI{} = url, {type, _} = body, options) when type in [:form, :json] do
+    IO.warn(
+      "Req.put!(url, {:#{type}, #{type}}, options) is deprecated in favour of " <>
+        "Req.put!(url, [body: {:#{type}, #{type}}] ++ options)"
+    )
+
+    request!([method: :put, url: url, body: body] ++ options)
   end
 
   @doc """
   Makes a DELETE request.
 
-  See `request/3` for a list of supported options.
+  See `request/1` for a list of supported options.
   """
-  @spec delete!(url(), keyword()) :: Req.Response.t()
+  @spec delete!(url(), options :: keyword()) :: Req.Response.t()
   def delete!(url, options \\ []) do
-    request!(:delete, url, options)
+    request!([method: :delete, url: url] ++ options)
   end
 
   @doc """
@@ -57,45 +187,137 @@ defmodule Req do
 
   ## Options
 
-    * `:headers` - request headers, defaults to `[]`
+    * `:method` - the request method, defaults to `:get`.
 
-    * `:body` - request body, defaults to `""`
+    * `:url` - the request URL.
 
-    * `:finch` - Finch pool to use, defaults to `Req.Finch` which is automatically started
-      by the application. See `Finch` module documentation for more information on starting pools.
+    * `:headers` - the request headers. The headers are automatically encoded using the `Req.Steps.encode_headers/1` step.
 
-    * `:finch_options` - Options passed down to Finch when making the request, defaults to `[]`.
-      See `Finch.request/3` for more information.
+    * `:body` - the request body. The body is automatically encoded using the `Req.Steps.encode_body/1` step.
 
-  The `options` are passed down to `Req.Steps.put_default_steps/2`, see its documentation for more
-  information how they are being used.
+    * `:base_url` - if set, the URL is prepended with this base URL. Defaults to `nil`.
+      See `Req.Steps.put_base_url/1` for more information.
 
-  The `options` are merged with default options set with `default_options/1`.
+    * `:params` - appends parameters to the request query string. Defaults to `[]`.
+      See `Req.Steps.put_params/1` for more information.
+
+    * `:raw` - if set to `true`, disables automatic body decompression (`Req.Steps.decompress/1`) and
+      and decoding (`Req.Steps.decode_body/1`). Defaults to `false`.
+
+    * `:adapter` - adapter to use to make the actual HTTP request. See `:adapter` field description
+      in the `Req.Request` module documentation for more information. Defaults to calling `Req.Steps.run_finch/1`.
+
+  `put_if_modified_since/1` options:
+
+    * `:cache` - if `true`, performs caching. Defaults to `false`.
+
+    * `:dir` - the directory to store the cache, defaults to `<user_cache_dir>/req`
+      (see: `:filename.basedir/3`)
+
+  `follow_redirects/1` options:
+
+    * `:follow_redirects` - if set to `false`, disables automatic response redirects. Defaults to `true`.
+
+    * `:max_redirects` - the maximum number of redirects. Defaults to `3`.
+
+  `run_finch/1` options:
+
+    * `:finch` - the `Finch` pool to use. Defaults to `Req.Finch` which is automatically started by `Req`.
+
+    * `:finch_options` - options passed down to Finch when making the request, defaults to `[]`.
+       See `Finch.request/3` for a list of available options.
+
+  ## Examples
+
+      iex> {:ok, response} = Req.request(url: "https://api.github.com/repos/elixir-lang/elixir")
+      iex> response.body
+      "Elixir is a dynamic, functional language designed for building scalable and maintainable applications"
+
+      iex> req = Req.new(url: "https://api.github.com/repos/elixir-lang/elixir")
+      iex> {:ok, %Req.Response{}} = Req.request(req)
+
+      iex> req = Req.new(base_url: "https://api.github.com")
+      iex> {:ok, %Req.Response{}} = Req.request(req, url: "/repos/elixir-lang/elixir")
   """
-  @spec request(method(), url(), keyword()) ::
+  @spec request(Req.Request.t() | keyword()) ::
           {:ok, Req.Response.t()} | {:error, Exception.t()}
-  def request(method, url, options \\ []) do
+  def request(request_or_options)
+
+  def request(%Req.Request{} = request) do
+    request(request, [])
+  end
+
+  def request(options) do
+    request(Req.new(options), [])
+  end
+
+  @doc """
+  Makes an HTTP request.
+  """
+  @spec request(Req.Request.t(), options :: keyword()) ::
+          {:ok, Req.Response.t()} | {:error, Exception.t()}
+  def request(request, options) do
     options = Keyword.merge(default_options(), options)
 
-    method
-    |> Req.Request.build(url, options)
-    |> Req.Steps.put_default_steps(options)
-    |> Req.Request.run()
+    {request, options} =
+      Enum.reduce([:method, :url, :headers, :body], {request, options}, fn option,
+                                                                           {request, options} ->
+        case Keyword.fetch(options, option) do
+          {:ok, value} ->
+            value =
+              if option == :url do
+                URI.parse(value)
+              else
+                value
+              end
+
+            # TODO: merge headers
+
+            {%{request | option => value}, Keyword.delete(options, option)}
+
+          :error ->
+            {request, options}
+        end
+      end)
+
+    request = update_in(request.options, &Map.merge(&1, Map.new(options)))
+    Req.Request.run(request)
+  end
+
+  @doc false
+  def request(method, url, options) do
+    IO.warn(
+      "Req.request(method, url, options) is deprecated in favour of " <>
+        "Req.request!([method: method, url: url] ++ options)"
+    )
+
+    request([method: method, url: URI.parse(url)] ++ options)
   end
 
   @doc """
   Makes an HTTP request and returns a response or raises an error.
 
-  See `request/3` for more information.
+  See `request/1` for more information.
   """
-  @spec request!(method(), url(), keyword()) :: Req.Response.t()
-  def request!(method, url, options \\ []) do
-    options = Keyword.merge(default_options(), options)
+  @spec request!(Req.Request.t() | keyword()) :: Req.Response.t()
+  def request!(request_or_options) do
+    case request(request_or_options) do
+      {:ok, response} -> response
+      {:error, exception} -> raise exception
+    end
+  end
 
-    method
-    |> Req.Request.build(url, options)
-    |> Req.Steps.put_default_steps(options)
-    |> Req.Request.run!()
+  @doc """
+  Makes an HTTP request and returns a response or raises an error.
+
+  See `request/1` for more information.
+  """
+  @spec request!(Req.Request.t(), options :: keyword()) :: Req.Response.t()
+  def request!(request, options) do
+    case request(request, options) do
+      {:ok, response} -> response
+      {:error, exception} -> raise exception
+    end
   end
 
   @doc """
@@ -111,8 +333,7 @@ defmodule Req do
   @doc """
   Sets default options.
 
-  The default options are used by `get!/2`, `post!/3`, `put!/3`,
-  `delete!/2`, `request/3`, and `request!/3` functions.
+  The default options are used by `request/1`, `get!/2`, and similar functions.
 
   Avoid setting default options in libraries as they are global.
   """

--- a/lib/req.ex
+++ b/lib/req.ex
@@ -38,7 +38,7 @@ defmodule Req do
   @type method() :: :get | :post | :put | :delete
 
   @doc """
-  Returns a new request struct with default steps.
+  Returns a new request struct with built-in steps.
 
   See `request/1` for a list of available options. See `Req.Request` module documentation
   for more information on the underlying request struct.

--- a/lib/req.ex
+++ b/lib/req.ex
@@ -1,10 +1,37 @@
 defmodule Req do
   @external_resource "README.md"
 
-  @moduledoc "README.md"
-             |> File.read!()
-             |> String.split("<!-- MDOC !-->")
-             |> Enum.fetch!(1)
+  @moduledoc """
+  The high-level API.
+
+  Req is composed of three main pieces:
+
+    * `Req` - the high-level API (you're here!)
+
+    * `Req.Request` - the low-level API and the request struct
+
+    * `Req.Steps` - the collection of built-in steps
+
+  The high-level API is what most users of Req will use most of the time.
+
+  ## Examples
+
+  Making a GET request with `Req.get!/1`:
+
+      iex> Req.get!("https://api.github.com/repos/elixir-lang/elixir").body["description"]
+      "Elixir is a dynamic, functional language designed for building scalable and maintainable applications"
+
+  Same, but by explicitly building request struct first:
+
+      iex> req = Req.new(base_url: "https://api.github.com")
+      iex> Req.get!(req, url: "/repos/elixir-lang/elixir").body["description"]
+      "Elixir is a dynamic, functional language designed for building scalable and maintainable applications"
+
+  Making a POST request with `Req.post!/2`:
+
+      iex> Req.post!("https://httpbin.org/post", body: {:form, comments: "hello!"}).body["form"]
+      %{"comments" => "hello!"}
+  """
 
   @type url() :: URI.t() | String.t()
 
@@ -13,7 +40,17 @@ defmodule Req do
   @doc """
   Returns a new request struct with default steps.
 
-  See `request/1` for a list of available options.
+  See `request/1` for a list of available options. See `Req.Request` module documentation
+  for more information on the underlying request struct.
+
+  ## Examples
+
+      iex> req = Req.new(url: "https://elixir-lang.org")
+      iex> req.method
+      :get
+      iex> URI.to_string(req.url)
+      "https://elixir-lang.org"
+
   """
   @spec new(options :: keyword()) :: Req.Request.t()
   def new(options \\ []) do
@@ -224,15 +261,14 @@ defmodule Req do
   Additional URL options:
 
     * `:base_url` - if set, the URL is prepended with this base URL (via
-      [`put_base_url`](`Req.Steps.put_base_url/1`) step).  Defaults to `nil`.
+      [`put_base_url`](`Req.Steps.put_base_url/1`) step).
 
-    * `:params` - appends parameters to the request query string (via
-      [`put_params`](`Req.Steps.put_params/1`) step). Defaults to `[]`.
+    * `:params` - if set, appends parameters to the request query string (via
+      [`put_params`](`Req.Steps.put_params/1`) step).
 
   Authentication options:
 
-    * `:auth` - if present, sets request authentication (. Defaults to `nil`. See
-      [`auth`](`Req.Steps.auth/1`) step.
+    * `:auth` - sets request authentication (via [`auth`](`Req.Steps.auth/1`) step).
 
   Response body options:
 

--- a/lib/req.ex
+++ b/lib/req.ex
@@ -10,29 +10,6 @@ defmodule Req do
 
   @type method() :: :get | :post | :put | :delete
 
-  @default_options %{
-    # request steps
-    auth: nil,
-    base_url: nil,
-    cache: nil,
-    cache_dir: nil,
-    params: [],
-    range: nil,
-    finch: Req.Finch,
-    pool_timeout: 5000,
-    receive_timeout: 15000,
-
-    # response steps
-    follow_redirects: true,
-    location_trusted: false,
-    raw: false,
-
-    # error steps
-    max_retries: 2,
-    retry: true,
-    retry_delay: 2000
-  }
-
   @doc """
   Returns a new request struct with default steps.
 
@@ -45,7 +22,7 @@ defmodule Req do
     {url, options} = Keyword.pop(options, :url, nil)
     {headers, options} = Keyword.pop(options, :headers, [])
     {body, options} = Keyword.pop(options, :body, "")
-    options = Map.merge(@default_options, Map.new(options))
+    options = Map.new(options)
 
     %Req.Request{
       adapter: adapter,

--- a/lib/req/request.ex
+++ b/lib/req/request.ex
@@ -10,8 +10,10 @@ defmodule Req.Request do
 
     * `Req.Steps` - the collection of built-in steps
 
-  The low-level API, the request struct and the associated functions, is the foundation of Req's
-  extensibility.
+  The low-level API and the request struct is the foundation of Req's extensibility. Virtually all
+  of the functionality is broken down into individual pieces - steps. Req works by running the
+  request struct through these steps. You can easily reuse or rearrange built-in steps or write new
+  ones.
 
   ## The request struct
 
@@ -23,15 +25,6 @@ defmodule Req.Request do
 
     * `:body` - the HTTP request body
 
-    * `:adapter` - a request step that makes the actual HTTP request. The adapter
-      is automatically added by Req as the very last request step. The adapter must
-      return `{request, response}` or `{request, exception}`, thus triggering the
-      response or error pipeline, respectively. Defaults to `Req.Steps.run_finch/1`.
-
-    * `:unix_socket` - if set, connect through the given UNIX domain socket
-
-    * `:halted` - whether the request pipeline is halted. See `halt/1`
-
     * `:request_steps` - the list of request steps
 
     * `:response_steps` - the list of response steps
@@ -42,9 +35,18 @@ defmodule Req.Request do
       Prefix the keys with the name of your project to avoid any future
       conflicts. Only accepts `t:atom/0` keys.
 
+    * `:halted` - whether the request pipeline is halted. See `halt/1`
+
+    * `:adapter` - a request step that makes the actual HTTP request. The adapter
+      is automatically added by Req as the very last request step. The adapter must
+      return `{request, response}` or `{request, exception}`, thus triggering the
+      response or error pipeline, respectively. Defaults to `Req.Steps.run_finch/1`.
+
+    * `:unix_socket` - if set, connect through the given UNIX domain socket
+
   ## Steps
 
-  Under the hood, Req works by passing a [`%Req.Request{}`](`Req.Request`) struct through a series of steps.
+  Req has three types of steps: request, response, and error.
 
   Request steps are used to refine the data that will be sent to the server.
 

--- a/lib/req/request.ex
+++ b/lib/req/request.ex
@@ -1,25 +1,19 @@
 defmodule Req.Request do
-  @type t() :: %Req.Request{
-          method: :get | :post | :put | :head | :delete,
-          url: URI.t(),
-          headers: [{binary(), binary()}],
-          body: binary(),
-          options: keyword(),
-          adapter: request_step(),
-          request_steps: [request_step()],
-          response_steps: [response_step()],
-          error_steps: [error_step()],
-          private: map()
-        }
-
-  @typep request_step() :: fun()
-  @typep response_step() :: fun()
-  @typep error_step() :: fun()
-
   @moduledoc ~S"""
-  The request pipeline struct.
+  The low-level API and the request struct.
 
-  Struct fields:
+  Req is composed of three main pieces:
+
+    * `Req` - the high-level API
+
+    * `Req.Request` - the low-level API and the request struct (you're here!)
+
+    * `Req.Steps` - the collection of built-in steps
+
+  The low-level API, the request struct and the associated functions, is the foundation of Req's
+  extensibility.
+
+  ## The request struct
 
     * `:method` - the HTTP request method
 
@@ -133,6 +127,23 @@ defmodule Req.Request do
       end
   """
 
+  @type t() :: %Req.Request{
+          method: :get | :post | :put | :head | :delete,
+          url: URI.t(),
+          headers: [{binary(), binary()}],
+          body: binary(),
+          options: keyword(),
+          adapter: request_step(),
+          request_steps: [request_step()],
+          response_steps: [response_step()],
+          error_steps: [error_step()],
+          private: map()
+        }
+
+  @typep request_step() :: fun()
+  @typep response_step() :: fun()
+  @typep error_step() :: fun()
+
   defstruct method: :get,
             url: nil,
             headers: [],
@@ -146,17 +157,6 @@ defmodule Req.Request do
             error_steps: [],
             private: %{},
             location_trusted: false
-
-  @doc """
-  Returns a new request struct.
-  """
-  def new(options \\ []) do
-    options =
-      options
-      |> Keyword.update(:url, nil, &URI.parse/1)
-
-    struct!(__MODULE__, options)
-  end
 
   @doc """
   Sets the request adapter.
@@ -190,6 +190,7 @@ defmodule Req.Request do
     %{request | halted: true}
   end
 
+  @doc false
   @deprecated "Use new/1 instead"
   def build(method, url, options \\ []) do
     %Req.Request{

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -17,9 +17,9 @@ defmodule Req.Steps do
   ## Examples
 
       iex> req = Req.new(base_url: "https://httpbin.org")
-      iex> Req.get!(req, "/status/200").status
+      iex> Req.get!(req, url: "/status/200").status
       200
-      iex> Req.get!(req, "/status/201").status
+      iex> Req.get!(req, url: "/status/201").status
       201
   """
   @doc step: :request

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1,6 +1,14 @@
 defmodule Req.Steps do
   @moduledoc """
-  A collection of built-in steps.
+  The collection of built-in steps.
+
+  Req is composed of three main pieces:
+
+    * `Req` - the high-level API
+
+    * `Req.Request` - the low-level API and the request struct
+
+    * `Req.Steps` - the collection of built-in steps (you're here!)
   """
 
   require Logger

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -10,12 +10,16 @@ defmodule Req.Steps do
   @doc """
   Sets base URL for all requests.
 
+  ## Request Options:
+
+    * `:base_url` - the base URL
+
   ## Examples
 
-      iex> options = [base_url: "https://httpbin.org"]
-      iex> Req.get!("/status/200", options).status
+      iex> req = Req.new(base_url: "https://httpbin.org")
+      iex> Req.get!(req, "/status/200").status
       200
-      iex> Req.get!("/status/201", options).status
+      iex> Req.get!(req, "/status/201").status
       201
   """
   @doc step: :request

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -270,11 +270,11 @@ defmodule Req.Steps do
     put_params(request, Map.get(request.options, :params, []))
   end
 
-  def put_params(request, []) do
+  defp put_params(request, []) do
     request
   end
 
-  def put_params(request, params) do
+  defp put_params(request, params) do
     encoded = URI.encode_query(params)
 
     update_in(request.url.query, fn

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule Req.MixProject do
 
   defp docs do
     [
-      main: "Req",
+      main: "readme",
       source_url: @source_url,
       source_ref: "v#{@version}",
       groups_for_functions: [
@@ -65,6 +65,7 @@ defmodule Req.MixProject do
         "Error steps": &(&1[:step] == :error)
       ],
       extras: [
+        "README.md",
         "CHANGELOG.md"
       ]
     ]

--- a/test/req/httpbin_test.exs
+++ b/test/req/httpbin_test.exs
@@ -15,14 +15,14 @@ defmodule Req.HttpbinTest do
 
   doctest Req.Steps,
     only: [
-      auth: 2,
-      put_base_url: 2,
+      auth: 1,
+      put_base_url: 1,
       encode_headers: 1,
       encode_body: 1,
-      put_params: 2,
-      put_range: 2,
-      run_steps: 2,
-      put_if_modified_since: 2,
+      put_params: 1,
+      put_range: 1,
+      # run_steps: 1,
+      put_if_modified_since: 1,
       decompress: 1,
       decode_body: 1
     ]

--- a/test/req/request_test.exs
+++ b/test/req/request_test.exs
@@ -11,7 +11,7 @@ defmodule Req.RequestTest do
       Plug.Conn.send_resp(conn, 200, "ok")
     end)
 
-    request = Req.Request.build(:get, c.url <> "/ok")
+    request = Req.Request.new(url: c.url <> "/ok")
     assert {:ok, %{status: 200, body: "ok"}} = Req.Request.run(request)
   end
 
@@ -21,7 +21,7 @@ defmodule Req.RequestTest do
     end)
 
     request =
-      Req.Request.build(:get, c.url <> "/not-found")
+      Req.Request.new(url: c.url <> "/not-found")
       |> Req.Request.prepend_request_steps([
         fn request ->
           put_in(request.url.path, "/ok")
@@ -33,7 +33,7 @@ defmodule Req.RequestTest do
 
   test "request step returns response", c do
     request =
-      Req.Request.build(:get, c.url <> "/ok")
+      Req.Request.new(url: c.url <> "/ok")
       |> Req.Request.prepend_request_steps([
         fn request ->
           {request, %Req.Response{status: 200, body: "from cache"}}
@@ -50,7 +50,7 @@ defmodule Req.RequestTest do
 
   test "request step returns exception", c do
     request =
-      Req.Request.build(:get, c.url <> "/ok")
+      Req.Request.new(url: c.url <> "/ok")
       |> Req.Request.prepend_request_steps([
         fn request ->
           {request, RuntimeError.exception("oops")}
@@ -67,7 +67,7 @@ defmodule Req.RequestTest do
 
   test "request step halts with response", c do
     request =
-      Req.Request.build(:get, c.url <> "/ok")
+      Req.Request.new(url: c.url <> "/ok")
       |> Req.Request.prepend_request_steps([
         fn request ->
           {Req.Request.halt(request), %Req.Response{status: 200, body: "from cache"}}
@@ -86,7 +86,7 @@ defmodule Req.RequestTest do
 
   test "request step halts with exception", c do
     request =
-      Req.Request.build(:get, c.url <> "/ok")
+      Req.Request.new(url: c.url <> "/ok")
       |> Req.Request.prepend_request_steps([
         fn request ->
           {Req.Request.halt(request), RuntimeError.exception("oops")}
@@ -109,7 +109,7 @@ defmodule Req.RequestTest do
     end)
 
     request =
-      Req.Request.build(:get, c.url <> "/ok")
+      Req.Request.new(url: c.url <> "/ok")
       |> Req.Request.prepend_response_steps([
         fn {request, response} ->
           {request, update_in(response.body, &(&1 <> " - updated"))}
@@ -125,7 +125,7 @@ defmodule Req.RequestTest do
     end)
 
     request =
-      Req.Request.build(:get, c.url <> "/ok")
+      Req.Request.new(url: c.url <> "/ok")
       |> Req.Request.prepend_response_steps([
         fn {request, response} ->
           assert response.body == "ok"
@@ -147,7 +147,7 @@ defmodule Req.RequestTest do
     end)
 
     request =
-      Req.Request.build(:get, c.url <> "/ok")
+      Req.Request.new(url: c.url <> "/ok")
       |> Req.Request.prepend_response_steps([
         fn {request, response} ->
           {Req.Request.halt(request), update_in(response.body, &(&1 <> " - updated"))}
@@ -167,7 +167,7 @@ defmodule Req.RequestTest do
     end)
 
     request =
-      Req.Request.build(:get, c.url <> "/ok")
+      Req.Request.new(url: c.url <> "/ok")
       |> Req.Request.prepend_response_steps([
         fn {request, response} ->
           assert response.body == "ok"
@@ -186,7 +186,7 @@ defmodule Req.RequestTest do
     Bypass.down(c.bypass)
 
     request =
-      Req.Request.build(:get, c.url <> "/ok")
+      Req.Request.new(url: c.url <> "/ok")
       |> Req.Request.prepend_error_steps([
         fn {request, exception} ->
           assert exception.reason == :econnrefused
@@ -201,7 +201,7 @@ defmodule Req.RequestTest do
     Bypass.down(c.bypass)
 
     request =
-      Req.Request.build(:get, c.url <> "/ok")
+      Req.Request.new(url: c.url <> "/ok")
       |> Req.Request.prepend_response_steps([
         fn {request, response} ->
           {request, update_in(response.body, &(&1 <> " - updated"))}
@@ -222,7 +222,7 @@ defmodule Req.RequestTest do
     Bypass.down(c.bypass)
 
     request =
-      Req.Request.build(:get, c.url <> "/ok")
+      Req.Request.new(url: c.url <> "/ok")
       |> Req.Request.prepend_response_steps([
         &unreachable/1
       ])

--- a/test/req/request_test.exs
+++ b/test/req/request_test.exs
@@ -11,7 +11,7 @@ defmodule Req.RequestTest do
       Plug.Conn.send_resp(conn, 200, "ok")
     end)
 
-    request = Req.Request.new(url: c.url <> "/ok")
+    request = new(url: c.url <> "/ok")
     assert {:ok, %{status: 200, body: "ok"}} = Req.Request.run(request)
   end
 
@@ -21,7 +21,7 @@ defmodule Req.RequestTest do
     end)
 
     request =
-      Req.Request.new(url: c.url <> "/not-found")
+      new(url: c.url <> "/not-found")
       |> Req.Request.prepend_request_steps([
         fn request ->
           put_in(request.url.path, "/ok")
@@ -33,7 +33,7 @@ defmodule Req.RequestTest do
 
   test "request step returns response", c do
     request =
-      Req.Request.new(url: c.url <> "/ok")
+      new(url: c.url <> "/ok")
       |> Req.Request.prepend_request_steps([
         fn request ->
           {request, %Req.Response{status: 200, body: "from cache"}}
@@ -50,7 +50,7 @@ defmodule Req.RequestTest do
 
   test "request step returns exception", c do
     request =
-      Req.Request.new(url: c.url <> "/ok")
+      new(url: c.url <> "/ok")
       |> Req.Request.prepend_request_steps([
         fn request ->
           {request, RuntimeError.exception("oops")}
@@ -67,7 +67,7 @@ defmodule Req.RequestTest do
 
   test "request step halts with response", c do
     request =
-      Req.Request.new(url: c.url <> "/ok")
+      new(url: c.url <> "/ok")
       |> Req.Request.prepend_request_steps([
         fn request ->
           {Req.Request.halt(request), %Req.Response{status: 200, body: "from cache"}}
@@ -86,7 +86,7 @@ defmodule Req.RequestTest do
 
   test "request step halts with exception", c do
     request =
-      Req.Request.new(url: c.url <> "/ok")
+      new(url: c.url <> "/ok")
       |> Req.Request.prepend_request_steps([
         fn request ->
           {Req.Request.halt(request), RuntimeError.exception("oops")}
@@ -109,7 +109,7 @@ defmodule Req.RequestTest do
     end)
 
     request =
-      Req.Request.new(url: c.url <> "/ok")
+      new(url: c.url <> "/ok")
       |> Req.Request.prepend_response_steps([
         fn {request, response} ->
           {request, update_in(response.body, &(&1 <> " - updated"))}
@@ -125,7 +125,7 @@ defmodule Req.RequestTest do
     end)
 
     request =
-      Req.Request.new(url: c.url <> "/ok")
+      new(url: c.url <> "/ok")
       |> Req.Request.prepend_response_steps([
         fn {request, response} ->
           assert response.body == "ok"
@@ -147,7 +147,7 @@ defmodule Req.RequestTest do
     end)
 
     request =
-      Req.Request.new(url: c.url <> "/ok")
+      new(url: c.url <> "/ok")
       |> Req.Request.prepend_response_steps([
         fn {request, response} ->
           {Req.Request.halt(request), update_in(response.body, &(&1 <> " - updated"))}
@@ -167,7 +167,7 @@ defmodule Req.RequestTest do
     end)
 
     request =
-      Req.Request.new(url: c.url <> "/ok")
+      new(url: c.url <> "/ok")
       |> Req.Request.prepend_response_steps([
         fn {request, response} ->
           assert response.body == "ok"
@@ -186,7 +186,7 @@ defmodule Req.RequestTest do
     Bypass.down(c.bypass)
 
     request =
-      Req.Request.new(url: c.url <> "/ok")
+      new(url: c.url <> "/ok")
       |> Req.Request.prepend_error_steps([
         fn {request, exception} ->
           assert exception.reason == :econnrefused
@@ -201,7 +201,7 @@ defmodule Req.RequestTest do
     Bypass.down(c.bypass)
 
     request =
-      Req.Request.new(url: c.url <> "/ok")
+      new(url: c.url <> "/ok")
       |> Req.Request.prepend_response_steps([
         fn {request, response} ->
           {request, update_in(response.body, &(&1 <> " - updated"))}
@@ -222,7 +222,7 @@ defmodule Req.RequestTest do
     Bypass.down(c.bypass)
 
     request =
-      Req.Request.new(url: c.url <> "/ok")
+      new(url: c.url <> "/ok")
       |> Req.Request.prepend_response_steps([
         &unreachable/1
       ])
@@ -238,6 +238,11 @@ defmodule Req.RequestTest do
   end
 
   ## Helpers
+
+  defp new(options) do
+    options = Keyword.update(options, :url, nil, &URI.parse/1)
+    struct!(Req.Request, options)
+  end
 
   defp unreachable(_) do
     raise "unreachable"

--- a/test/req_test.exs
+++ b/test/req_test.exs
@@ -1,6 +1,11 @@
 defmodule ReqTest do
   use ExUnit.Case, async: true
 
+  doctest Req,
+    only: [
+      new: 1
+    ]
+
   setup do
     bypass = Bypass.open()
     [bypass: bypass, url: "http://localhost:#{bypass.port}"]

--- a/test/req_test.exs
+++ b/test/req_test.exs
@@ -17,24 +17,24 @@ defmodule ReqTest do
       assert Req.get!(c.url <> "/json").body == %{"a" => 1}
     end
 
-    test "post!/3", c do
+    test "post!/", c do
       Bypass.expect(c.bypass, "POST", "/json", fn conn ->
         conn
         |> Plug.Conn.put_resp_content_type("application/json")
         |> Plug.Conn.send_resp(200, Jason.encode_to_iodata!(%{"a" => 1}))
       end)
 
-      assert Req.post!(c.url <> "/json", {:json, %{foo: "bar"}}).body == %{"a" => 1}
+      assert Req.post!(c.url <> "/json", body: {:json, %{foo: "bar"}}).body == %{"a" => 1}
     end
 
-    test "put!/3", c do
+    test "put!/", c do
       Bypass.expect(c.bypass, "PUT", "/json", fn conn ->
         conn
         |> Plug.Conn.put_resp_content_type("application/json")
         |> Plug.Conn.send_resp(200, Jason.encode_to_iodata!(%{"a" => 1}))
       end)
 
-      assert Req.put!(c.url <> "/json", {:json, %{foo: "bar"}}).body == %{"a" => 1}
+      assert Req.put!(c.url <> "/json", body: {:json, %{foo: "bar"}}).body == %{"a" => 1}
     end
 
     test "delete!/2", c do
@@ -59,32 +59,5 @@ defmodule ReqTest do
     end)
 
     assert Req.get!(c.url <> "/json+gzip", raw: true).body == raw
-  end
-
-  ## Finch errors
-
-  test "pool timeout", c do
-    Bypass.stub(c.bypass, "GET", "/", fn conn ->
-      Plug.Conn.send_resp(conn, 200, "ok")
-    end)
-
-    options = [finch_options: [pool_timeout: 0]]
-    assert {:timeout, _} = catch_exit(Req.get!(c.url <> "/", options))
-  end
-
-  test "receive timeout", c do
-    Bypass.stub(c.bypass, "GET", "/", fn conn ->
-      Process.sleep(1000)
-      Plug.Conn.send_resp(conn, 200, "ok")
-    end)
-
-    options = [finch_options: [receive_timeout: 0]]
-
-    assert {:error, %Mint.TransportError{reason: :timeout}} =
-             Req.request(:get, c.url <> "/", options)
-
-    # TODO:
-    # when this is uncommented, we'll get an exit shutdown, figure out why
-    # Process.sleep(1000)
   end
 end


### PR DESCRIPTION
Major changes:

  * Add high-level functional API: `Req.new(options) |> Req.request(options)`

  * Add `Req.Request.options` field that steps can read from. Also, make
    all steps be arity 1.

    When using "High-level" API, we now run all steps by default. (The
    steps, by looking at `request.options`, can decide to be no-op.)

  * Remove `put_default_steps/2` step.

  * Remove `run_steps/2` step.

Deprecations:

  * Deprecate calling `Req.post!(url, body)` in favour of `Req.post(url,
    body: body)`. Same for `Req.put!`.

  * Deprecate setting `retry: [delay: delay, max_retries: max_retries]`
    in favour of `[retry_delay: delay, max_retries: max_retries]`.

  * Deprecate setting `follow_redirects: [location_trusted: trusted]`
    in favour of `[location_trusted: trusted]`.

  * Deprecate setting `cache: [dir: dir]` in favour of `cache_dir: dir`.

  * Deprecate `Req.Request.build/3` in favour of `Req.Request.new/1`.
