### PR TITLE
compress_request_step

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -76,7 +76,8 @@ defmodule Req do
         &Req.Steps.put_params/1,
         &Req.Steps.put_range/1,
         &Req.Steps.put_if_modified_since/1,
-        &Req.Steps.put_plug/1
+        &Req.Steps.put_plug/1,
+        &Req.Steps.compress_request/1
       ],
       response_steps: [
         &Req.Steps.retry/1,
@@ -357,6 +358,9 @@ defmodule Req do
 
     * `:body` - the request body. The body is automatically encoded using the
       [`encode_body`](`Req.Steps.encode_body/1`) step.
+
+    * `:compress_request` - compresses the request body via the
+      [`compress_request`](`Req.Steps.compress_request/1`) step.
 
   Additional URL options:
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -375,6 +375,26 @@ defmodule Req.Steps do
   end
 
   @doc """
+  Compresses the request body.
+
+  ## Request options
+
+    * `:compress_request` - compresses the request body using `gzip` compression and sets the
+    `"Content-Encoding: gzip"` header. Defaults to `false`.
+
+  """
+  @doc step: :request
+  def compress_request(request) do
+    if request.options[:compress_request] do
+      request
+      |> Map.put(:body, :zlib.gzip(request.body))
+      |> put_header("content-encoding", "gzip")
+    else
+      request
+    end
+  end
+
+  @doc """
   Runs the request using `Finch`.
 
   This is the default Req _adapter_. See `:adapter` field description in the `Req.Request` module

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -256,6 +256,15 @@ defmodule Req.StepsTest do
     assert resp.body =~ "Req is an HTTP client"
   end
 
+  test "compress_request/1" do
+    req = Req.new(method: :post, json: %{a: 1}) |> Req.Request.prepare()
+    assert Jason.decode!(req.body) == %{"a" => 1}
+
+    req = Req.new(method: :post, json: %{a: 1}, compress_request: true) |> Req.Request.prepare()
+    assert :zlib.gunzip(req.body) |> Jason.decode!() == %{"a" => 1}
+    assert List.keyfind(req.headers, "content-encoding", 0) == {"content-encoding", "gzip"}
+  end
+
   ## Response steps
 
   test "decompress/1", c do


### PR DESCRIPTION
Closes #25.

I took liberties with the name as I thought `compress_request` was clearer.

I could not come up with a good example for the docs without using `prepare/1`. Unfortunately compressed requests to [httpbin.org are not decoded due to security risks](https://github.com/postmanlabs/httpbin/issues/577).