### PR TITLE
add compress_request step

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Req is an HTTP client with a focus on ease of use and composability, built on to
 
   * Extensibility via request, response, and error steps.
 
-  * Automatic body decompression (via [`compressed`][compressed] and [`decompress`][decompress] step)
+  * Request body compression and automatic response body decompression ([`compress_body`][compress_body],  [`compressed`][compressed], and [`decompress`][decompress] step)
 
-  * Automatic body encoding and decoding (via [`encode_body`][encode_body]
+  * Request body encoding and automatic response body decoding (via [`encode_body`][encode_body]
     and [`decode_body`][decode_body] steps)
 
   * Encode params as query string (via [`put_params`][put_params] step)
@@ -34,8 +34,6 @@ Req is an HTTP client with a focus on ease of use and composability, built on to
   * Setting base URL (via [`put_base_url`][put_base_url] step)
 
   * Running against a plug (via [`put_plug`][put_plug] step)
-
-  * Request compression (via [`compress_body`][compress_body] step)
 
   * Pluggable adapters (see ["Adapter" section in `Req.Request` module][adapter] documentation)
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Req is an HTTP client with a focus on ease of use and composability, built on to
 
   * Running against a plug (via [`put_plug`][put_plug] step)
 
+  * Request compression (via [`compress_body`][compress_body] step)
+
   * Pluggable adapters (see ["Adapter" section in `Req.Request` module][adapter] documentation)
 
 [req]: https://hexdocs.pm/req/Req.html
@@ -53,6 +55,7 @@ Req is an HTTP client with a focus on ease of use and composability, built on to
 [cache]: https://hexdocs.pm/req/Req.Steps.html#cache/1
 [put_base_url]: https://hexdocs.pm/req/Req.Steps.html#put_base_url/1
 [put_plug]: https://hexdocs.pm/req/Req.Steps.html#put_plug/1
+[compress_body]: https://hexdocs.pm/req/Req.Steps.html#compress_body/1
 [adapter]: https://hexdocs.pm/req/Req.Request.html#module-adapter
 
 ## Usage

--- a/lib/req.ex
+++ b/lib/req.ex
@@ -77,7 +77,7 @@ defmodule Req do
         put_range: &Req.Steps.put_range/1,
         cache: &Req.Steps.cache/1,
         put_plug: &Req.Steps.put_plug/1,
-        compress_request: &Req.Steps.compress_request/1
+        compress_body: &Req.Steps.compress_body/1
       ],
       response_steps: [
         retry: &Req.Steps.retry/1,
@@ -362,8 +362,8 @@ defmodule Req do
     * `:body` - the request body. The body is automatically encoded using the
       [`encode_body`](`Req.Steps.encode_body/1`) step.
 
-    * `:compress_request` - compresses the request body via the
-      [`compress_request`](`Req.Steps.compress_request/1`) step.
+    * `:compress_body` - compresses the request body via the
+      [`compress_body`](`Req.Steps.body/1`) step.
 
   Additional URL options:
 

--- a/lib/req.ex
+++ b/lib/req.ex
@@ -76,7 +76,8 @@ defmodule Req do
         put_params: &Req.Steps.put_params/1,
         put_range: &Req.Steps.put_range/1,
         cache: &Req.Steps.cache/1,
-        put_plug: &Req.Steps.put_plug/1
+        put_plug: &Req.Steps.put_plug/1,
+        compress_request: &Req.Steps.compress_request/1
       ],
       response_steps: [
         retry: &Req.Steps.retry/1,
@@ -360,6 +361,9 @@ defmodule Req do
 
     * `:body` - the request body. The body is automatically encoded using the
       [`encode_body`](`Req.Steps.encode_body/1`) step.
+
+    * `:compress_request` - compresses the request body via the
+      [`compress_request`](`Req.Steps.compress_request/1`) step.
 
   Additional URL options:
 

--- a/lib/req.ex
+++ b/lib/req.ex
@@ -363,7 +363,7 @@ defmodule Req do
       [`encode_body`](`Req.Steps.encode_body/1`) step.
 
     * `:compress_body` - compresses the request body via the
-      [`compress_body`](`Req.Steps.body/1`) step.
+      [`compress_body`](`Req.Steps.compress_body/1`) step.
 
   Additional URL options:
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -377,17 +377,17 @@ defmodule Req.Steps do
   @doc """
   Compresses the request body.
 
-  ## Request options
+  ## Request Options
 
-    * `:compress_request` - compresses the request body using `gzip` compression and sets the
+    * `:compress_body` - compresses the request body using `gzip` compression and sets the
     `"Content-Encoding: gzip"` header. Defaults to `false`.
 
   """
   @doc step: :request
-  def compress_request(request) do
-    if request.options[:compress_request] do
+  def compress_body(request) do
+    if request.options[:compress_body] do
       request
-      |> Map.put(:body, :zlib.gzip(request.body))
+      |> Map.update!(:body, &:zlib.gzip/1)
       |> put_header("content-encoding", "gzip")
     else
       request

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -379,7 +379,7 @@ defmodule Req.Steps do
 
   ## Request Options
 
-    * `:compress_body` - compresses the request body using `gzip` compression and sets the
+    * `:compress_body` - compresses the request body using gzip and sets the
     `"Content-Encoding: gzip"` header. Defaults to `false`.
 
   """

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -379,8 +379,8 @@ defmodule Req.Steps do
 
   ## Request Options
 
-    * `:compress_body` - compresses the request body using gzip and sets the
-    `"Content-Encoding: gzip"` header. Defaults to `false`.
+    * `:compress_body` - if set to `true`, compresses the request body using gzip.
+      Defaults to `false`.
 
   """
   @doc step: :request

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -375,6 +375,26 @@ defmodule Req.Steps do
   end
 
   @doc """
+  Compresses the request body.
+
+  ## Request options
+
+    * `:compress_request` - compresses the request body using `gzip` compression and sets the
+    `"Content-Encoding: gzip"` header. Defaults to `false`.
+
+  """
+  @doc step: :request
+  def compress_request(request) do
+    if request.options[:compress_request] do
+      request
+      |> Map.put(:body, :zlib.gzip(request.body))
+      |> put_header("content-encoding", "gzip")
+    else
+      request
+    end
+  end
+
+  @doc """
   Runs the request using `Finch`.
 
   This is the default Req _adapter_. See `:adapter` field description in the `Req.Request` module

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -234,11 +234,11 @@ defmodule Req.StepsTest do
     assert resp.body =~ "Req is an HTTP client"
   end
 
-  test "compress_request/1" do
+  test "compress_body/1" do
     req = Req.new(method: :post, json: %{a: 1}) |> Req.Request.prepare()
     assert Jason.decode!(req.body) == %{"a" => 1}
 
-    req = Req.new(method: :post, json: %{a: 1}, compress_request: true) |> Req.Request.prepare()
+    req = Req.new(method: :post, json: %{a: 1}, compress_body: true) |> Req.Request.prepare()
     assert :zlib.gunzip(req.body) |> Jason.decode!() == %{"a" => 1}
     assert List.keyfind(req.headers, "content-encoding", 0) == {"content-encoding", "gzip"}
   end

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -234,6 +234,15 @@ defmodule Req.StepsTest do
     assert resp.body =~ "Req is an HTTP client"
   end
 
+  test "compress_request/1" do
+    req = Req.new(method: :post, json: %{a: 1}) |> Req.Request.prepare()
+    assert Jason.decode!(req.body) == %{"a" => 1}
+
+    req = Req.new(method: :post, json: %{a: 1}, compress_request: true) |> Req.Request.prepare()
+    assert :zlib.gunzip(req.body) |> Jason.decode!() == %{"a" => 1}
+    assert List.keyfind(req.headers, "content-encoding", 0) == {"content-encoding", "gzip"}
+  end
+
   ## Response steps
 
   test "decompress/1", c do


### PR DESCRIPTION
Closes #25.

I took liberties with the name as I thought `compress_request` was clearer.

I could not come up with a good example for the docs without using `prepare/1`. Unfortunately compressed requests to [httpbin.org are not decoded due to security risks](https://github.com/postmanlabs/httpbin/issues/577).