### PR TITLE
Fix typo in Req.Request moduledoc

### DIFF
--- a/lib/req/request.ex
+++ b/lib/req/request.ex
@@ -16,7 +16,7 @@ defmodule Req.Request do
   ones.
 
   To make using custom steps by others even easier, they can be packaged up into plugins.
-  See ["Wriging Plugins"](#module-writing-plugins) section for more information.
+  See ["Writing Plugins"](#module-writing-plugins) section for more information.
 
   ## The Low-level API
 

--- a/lib/req/request.ex
+++ b/lib/req/request.ex
@@ -411,7 +411,7 @@ defmodule Req.Request do
 
   ## Examples
 
-      Req.Request.append_request_steps(request,
+      Req.Request.append_response_steps(request,
         noop: fn {request, response} -> {request, response} end,
         inspect: &IO.inspect/1
       )
@@ -425,7 +425,7 @@ defmodule Req.Request do
 
   ## Examples
 
-      Req.Request.prepend_request_steps(request,
+      Req.Request.prepend_response_steps(request,
         noop: fn {request, response} -> {request, response} end,
         inspect: &IO.inspect/1
       )


### PR DESCRIPTION
Noticed this while reading through the new docs for the 0.3 release! If it's easier for you to just make this change yourself, please feel free to do so and close this PR. Cheers.