### PR TITLE
Add naive multipart/form-data capabilities to `Req.Steps.encode_body/1`.

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -100,6 +100,7 @@ defmodule Req do
           :params,
           :auth,
           :form,
+          :form_multi,
           :json,
           :compress_body,
           :compressed,


### PR DESCRIPTION
Hi,

Thanks for a great package! I have simplified a couple of projects a lot with it! 🎉 

This PR adds multipart/form-data encoding for very simple forms. (I ran into an API that only accepts this).

Some notes:
- Files are not handled.
- I have a branch [here](https://github.com/Doerge/req/commit/13ea403e1d2cb43f9de54fd0d89d1c5ec254794b) with `Stream` body. Not sure if that is a good or bad idea in the overall architecture of Req, so I left it out for now. Maybe File streaming could be implemented on top of that?
- Tesla has a more solid implementation [here](https://github.com/elixir-tesla/tesla/blob/308a6761f012a21a01e68f0bf3e2dc409b44c7f9/lib/tesla/multipart.ex). Maybe someone wiser than me could cook up a better solution.

Let me know what you think of both this basic multipart/form-data PR, and the Stream branch.

Best,