### PR TITLE
Decode JSON when response is json-api mime type

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -853,7 +853,7 @@ defmodule Req.Steps do
     decode_body({request, response}, format(request, response))
   end
 
-  defp decode_body({request, response}, "json") do
+  defp decode_body({request, response}, format) when format in ~w(json json-api) do
     {request, update_in(response.body, &Jason.decode!/1)}
   end
 


### PR DESCRIPTION
Hi Wojtek! 👋

I'm not sure whether this would be the path to go, but just noticed that `json-api` responses don't call jason decode step because of the mime type, WDYT?

Cheers!

