### PR TITLE
Add proxy to connection options

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -700,6 +700,8 @@ defmodule Req do
 
         * `:protocol` - the HTTP protocol to use, defaults to `:http1`.
 
+        * `:proxy` - a proxy to use given in a format supported by the Mint package: A tuple `{schema, address, port, options}`.
+
     * `:pool_timeout` - pool checkout timeout in milliseconds, defaults to `5000`.
 
     * `:receive_timeout` - socket receive timeout in milliseconds, defaults to `15_000`.

--- a/lib/req.ex
+++ b/lib/req.ex
@@ -700,7 +700,9 @@ defmodule Req do
 
         * `:protocol` - the HTTP protocol to use, defaults to `:http1`.
 
-        * `:proxy` - a proxy to use given in a format supported by the Mint package: A tuple `{schema, address, port, options}`.
+        * `:proxy` - a `{schema, address, port, options}` tuple. See
+          [Mint "Proxying" documentation](https://hexdocs.pm/mint/Mint.HTTP.html#connect/4-proxying)
+          for more information.
 
     * `:pool_timeout` - pool checkout timeout in milliseconds, defaults to `5000`.
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -475,7 +475,9 @@ defmodule Req.Steps do
 
         * `:protocol` - the HTTP protocol to use, defaults to `:http1`.
 
-        * `:proxy` - a proxy to use given in a format supported by the Mint package: A tuple `{schema, address, port, options}`.
+        * `:proxy` - a `{schema, address, port, options}` tuple. See
+          [Mint "Proxying" documentation](https://hexdocs.pm/mint/Mint.HTTP.html#connect/4-proxying)
+          for more information.
 
     * `:pool_timeout` - pool checkout timeout in milliseconds, defaults to `5000`.
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -512,10 +512,15 @@ defmodule Req.Steps do
         :error ->
           cond do
             options = request.options[:connect_options] ->
-              Req.Request.validate_options(options, MapSet.new([:timeout, :protocol]))
+              Req.Request.validate_options(options, MapSet.new([:timeout, :proxy, :protocol]))
 
               pool_opts = [
-                conn_opts: [transport_opts: [timeout: options[:timeout] || 30_000]],
+                conn_opts: [
+                  proxy: options[:proxy] || nil,
+                  transport_opts: [
+                    timeout: options[:timeout] || 30_000
+                  ]
+                ],
                 protocol: options[:protocol] || :http1
               ]
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -475,6 +475,8 @@ defmodule Req.Steps do
 
         * `:protocol` - the HTTP protocol to use, defaults to `:http1`.
 
+        * `:proxy` - a proxy to use given in a format supported by the Mint package: A tuple `{schema, address, port, options}`.
+
     * `:pool_timeout` - pool checkout timeout in milliseconds, defaults to `5000`.
 
     * `:receive_timeout` - socket receive timeout in milliseconds, defaults to `15_000`.
@@ -512,14 +514,14 @@ defmodule Req.Steps do
         :error ->
           cond do
             options = request.options[:connect_options] ->
-              Req.Request.validate_options(options, MapSet.new([:timeout, :proxy, :protocol]))
+              Req.Request.validate_options(options, MapSet.new([:timeout, :protocol, :proxy]))
 
               pool_opts = [
                 conn_opts: [
-                  proxy: options[:proxy] || nil,
                   transport_opts: [
                     timeout: options[:timeout] || 30_000
-                  ]
+                  ],
+                  proxy: options[:proxy]
                 ],
                 protocol: options[:protocol] || :http1
               ]

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -518,13 +518,15 @@ defmodule Req.Steps do
             options = request.options[:connect_options] ->
               Req.Request.validate_options(options, MapSet.new([:timeout, :protocol, :proxy]))
 
+              proxy_opt = if is_nil(options[:proxy]), do: [], else: [proxy: options[:proxy]]
+
               pool_opts = [
-                conn_opts: [
-                  transport_opts: [
-                    timeout: options[:timeout] || 30_000
-                  ],
-                  proxy: options[:proxy]
-                ],
+                conn_opts:
+                  [
+                    transport_opts: [
+                      timeout: options[:timeout] || 30_000
+                    ]
+                  ] ++ proxy_opt,
                 protocol: options[:protocol] || :http1
               ]
 

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -1043,17 +1043,17 @@ defmodule Req.StepsTest do
       Plug.Conn.send_resp(conn, 200, "ok")
     end)
 
+    # Bypass will forward request to itself
     # Not quite a proper forward proxy server, but good enough
     test_proxy = {:http, "localhost", c.bypass.port, []}
 
     req =
       Req.new(
-        base_url: c.url, # Bypass forwards request to itself
-        url: "/foo/bar",
+        base_url: c.url,
         connect_options: [proxy: test_proxy]
       )
 
-    assert Req.request!(req).body == "ok"
+    assert Req.request!(req, url: "/foo/bar").body == "ok"
   end
 
   test "run_finch/1: :connect_options bad option", c do

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -1038,6 +1038,24 @@ defmodule Req.StepsTest do
     assert Req.request!(req).body == "ok"
   end
 
+  test "run_finch/1: :connect_options :proxy", c do
+    Bypass.expect(c.bypass, "GET", "/foo/bar", fn conn ->
+      Plug.Conn.send_resp(conn, 200, "ok")
+    end)
+
+    # Not quite a proper forward proxy server, but good enough
+    test_proxy = {:http, "localhost", c.bypass.port, []}
+
+    req =
+      Req.new(
+        base_url: c.url, # Bypass forwards request to itself
+        url: "/foo/bar",
+        connect_options: [proxy: test_proxy]
+      )
+
+    assert Req.request!(req).body == "ok"
+  end
+
   test "run_finch/1: :connect_options bad option", c do
     assert_raise ArgumentError, "unknown option :timeou. Did you mean :timeout?", fn ->
       Req.get!(c.url, connect_options: [timeou: 0])


### PR DESCRIPTION
Hello,

I am using your package for a project of mine and it works very well. But at some point I had to use a proxy and I realized that I could not pass a `:proxy` option directly to the request function call.

I really needed this feature, so I added a `:proxy` option that the user can pass along with `:timeout` and `:protocol`. The proxy must be provided in a format supported by the [Mint](https://github.com/elixir-mint/mint) package: A tuple `{scheme, address, port, opts}` that identifies the proxy to connect to. 

```elixir
# proxy with scheme 'https', ip '34.91.135.38' and port '80'
https_proxy = {:https, "34.91.135.38", 80, []}

req = Req.get!("https://api.github.com/repos/sneako/finch", proxy: https_proxy)
```
Also note that I did not implement any extra tests after I added this feature. That's because I assume this is not a significant change for this project as I'm just passing an extra option to [Finch](https://github.com/sneako/finch) package.

I am already using this PR as a dependency in a personal project of mine called [exgooglenews](https://github.com/un3481/exgooglenews) and the proxy feature works just like I intended it to. What I want now is to have this feature in your Hex package so I can use your official package as a dependency.

Let me know what you think of this change.

Best regards.