### PR TITLE
Remove @external_resource

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -1,6 +1,4 @@
 defmodule Req do
-  @external_resource "README.md"
-
   @moduledoc """
   The high-level API.
 


### PR DESCRIPTION
The `@external_resource` was added in https://github.com/wojtekmach/req/commit/f7156a7f5e24dcdcf62240d221299c9f4f308a57 when the `@moduledoc` for `Req` depending on parsing the README.md. However that was subsequently removed so now the `@external_resource` line is only resulting in extraneous recompilation and can be safely removed.