### PR TITLE
Inherit scheme from previous location on redirection if needed

### DIFF
--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -663,6 +663,22 @@ defmodule Req.StepsTest do
     assert captured_log =~ "follow_redirects: redirecting to " <> c.url
   end
 
+  test "follow_redirects/1: inherit scheme", c do
+    "http:" <> no_scheme = c.url
+
+    Bypass.expect(c.bypass, "GET", "/redirect", fn conn ->
+      redirect(conn, 302, "#{no_scheme}/ok")
+    end)
+
+    Bypass.expect(c.bypass, "GET", "/ok", fn conn ->
+      Plug.Conn.send_resp(conn, 200, "ok")
+    end)
+
+    assert ExUnit.CaptureLog.capture_log(fn ->
+             assert Req.get!(c.url <> "/redirect").status == 200
+           end) =~ "[debug] follow_redirects: redirecting to #{no_scheme}/ok"
+  end
+
   defp redirect(conn, status, url) do
     conn
     |> Plug.Conn.put_resp_header("location", url)


### PR DESCRIPTION
This change allows to follow redirect locations such as `//other-host.com/a/b?c=d` where the scheme should be derived from the previous request.

I had to change the order of operations in `build_redirect_request/2` because I assumed that we want to put the scheme that will be used before comparing with the previous one in `remove_credentials_if_untrusted/2`.

Please let me know what you think.