### PR TITLE
`run_finch`: Add `:finch_request` option

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -80,11 +80,11 @@ defmodule Req do
           :cache_dir,
           :plug,
           :finch,
+          :finch_request,
           :connect_options,
           :receive_timeout,
           :pool_timeout,
-          :unix_socket,
-          :finch_request
+          :unix_socket
         ])
     }
     |> update(options)

--- a/lib/req.ex
+++ b/lib/req.ex
@@ -84,7 +84,7 @@ defmodule Req do
           :receive_timeout,
           :pool_timeout,
           :unix_socket,
-          :customize_finch
+          :finch_request
         ])
     }
     |> update(options)
@@ -764,8 +764,8 @@ defmodule Req do
 
     * `:unix_socket` - if set, connect through the given UNIX domain socket
     
-    * `:customize_finch` - a function to modify the built Finch request before execution. This function takes a 
-       Finch request and returns a Finch request. Defaults to the identity function.
+    * `:finch_request` - a function to modify the built Finch request before execution. This function takes a 
+       Finch request and returns a Finch request. If not provided, the finch request will not be modified
 
   ## Examples
 

--- a/lib/req.ex
+++ b/lib/req.ex
@@ -83,7 +83,8 @@ defmodule Req do
           :connect_options,
           :receive_timeout,
           :pool_timeout,
-          :unix_socket
+          :unix_socket,
+          :customize_finch
         ])
     }
     |> update(options)
@@ -762,6 +763,9 @@ defmodule Req do
     * `:receive_timeout` - socket receive timeout in milliseconds, defaults to `15_000`.
 
     * `:unix_socket` - if set, connect through the given UNIX domain socket
+    
+    * `:customize_finch` - a function to modify the built Finch request before execution. This function takes a 
+       Finch request and returns a Finch request. Defaults to the identity function.
 
   ## Examples
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -517,10 +517,12 @@ defmodule Req.Steps do
   @doc step: :request
   def run_finch(request) do
     finch_name = finch_name(request)
+    customize_function = customize_function(request)
 
     finch_request =
       Finch.build(request.method, request.url, request.headers, request.body)
       |> Map.replace!(:unix_socket, request.options[:unix_socket])
+      |> customize_function.()
 
     finch_options =
       request.options |> Map.take([:receive_timeout, :pool_timeout]) |> Enum.to_list()
@@ -607,6 +609,13 @@ defmodule Req.Steps do
           true ->
             Req.Finch
         end
+    end
+  end
+
+  defp customize_function(request) do
+    case Map.fetch(request.options, :customize_finch) do
+      {:ok, fun} -> fun
+      :error -> &Function.identity/1
     end
   end
 

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -910,21 +910,6 @@ defmodule Req.StepsTest do
     refute_received _
   end
 
-  test "customize finch", c do
-    Bypass.expect(c.bypass, "GET", "/ok", fn conn ->
-      Plug.Conn.send_resp(conn, 200, "ok")
-    end)
-
-    assert ExUnit.CaptureLog.capture_log(fn ->
-             assert Req.get!(c.url <> "/ok",
-                      finch_request: fn r ->
-                        Logger.debug("customize_finch function called")
-                        r
-                      end
-                    ).status == 200
-           end) =~ "[debug] customize_finch function called"
-  end
-
   @tag :tmp_dir
   test "cache", c do
     pid = self()
@@ -1019,6 +1004,22 @@ defmodule Req.StepsTest do
     end
 
     assert Req.request!(plug: plug, json: %{a: 1}).body == "ok"
+  end
+
+  test "run_finch: :finch_request", c do
+    Bypass.expect(c.bypass, "GET", "/ok", fn conn ->
+      Plug.Conn.send_resp(conn, 200, "ok")
+    end)
+
+    pid = self()
+
+    fun = fn request ->
+      send(pid, request)
+      request
+    end
+
+    assert Req.get!(c.url <> "/ok", finch_request: fun).body == "ok"
+    assert_received %Finch.Request{}
   end
 
   test "run_finch: pool timeout", c do


### PR DESCRIPTION
This PR allows an optional callback function to be passed as an options which allow modification of the Finch request object before it is executed.
