### PR TITLE
Allow customization of log level for retry messages

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -75,6 +75,7 @@ defmodule Req do
           :max_redirects,
           :retry,
           :retry_delay,
+          :retry_log_level,
           :max_retries,
           :cache,
           :cache_dir,

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1159,7 +1159,7 @@ defmodule Req.Steps do
       determine the next retry delay.
 
     * `:retry_log_level` - the log level to emit retry logs at. Can also be set to `false` to disable logging 
-      these messsages.
+      these messsages. Default to `:error` if not specified.
       
     * `:max_retries` - maximum number of retry attempts, defaults to `3` (for a total of `4`
       requests to the server, including the initial one.)
@@ -1228,7 +1228,7 @@ defmodule Req.Steps do
     retry_count = Req.Request.get_private(request, :req_retry_count, 0)
     {request, delay} = get_retry_delay(request, response_or_exception, retry_count)
     max_retries = Map.get(request.options, :max_retries, 3)
-    log_level = Map.get(request.options, :retry_log_level, :warn)
+    log_level = Map.get(request.options, :retry_log_level, :error)
 
     if retry_count < max_retries do
       log_retry(response_or_exception, retry_count, max_retries, delay, log_level)

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1158,6 +1158,9 @@ defmodule Req.Steps do
       If the response is HTTP 429 and contains the `retry-after` header, the value of the header is used to
       determine the next retry delay.
 
+    * `:retry_log_level` - the log level to emit retry logs at. Can also be set to `false` to disable logging 
+      these messsages.
+      
     * `:max_retries` - maximum number of retry attempts, defaults to `3` (for a total of `4`
       requests to the server, including the initial one.)
 
@@ -1225,9 +1228,10 @@ defmodule Req.Steps do
     retry_count = Req.Request.get_private(request, :req_retry_count, 0)
     {request, delay} = get_retry_delay(request, response_or_exception, retry_count)
     max_retries = Map.get(request.options, :max_retries, 3)
+    log_level = Map.get(request.options, :retry_log_level, :warn)
 
     if retry_count < max_retries do
-      log_retry(response_or_exception, retry_count, max_retries, delay)
+      log_retry(response_or_exception, retry_count, max_retries, delay, log_level)
       Process.sleep(delay)
       request = Req.Request.put_private(request, :req_retry_count, retry_count + 1)
 
@@ -1279,7 +1283,9 @@ defmodule Req.Steps do
     end
   end
 
-  defp log_retry(response_or_exception, retry_count, max_retries, delay) do
+  defp log_retry(_, _, _, _, false), do: :ok
+
+  defp log_retry(response_or_exception, retry_count, max_retries, delay, level) do
     retries_left =
       case max_retries - retry_count do
         1 -> "1 attempt"
@@ -1290,18 +1296,18 @@ defmodule Req.Steps do
 
     case response_or_exception do
       %{__exception__: true} = exception ->
-        Logger.error([
+        Logger.log(level, [
           "retry: got exception, ",
           message
         ])
 
-        Logger.error([
+        Logger.log(level, [
           "** (#{inspect(exception.__struct__)}) ",
           Exception.message(exception)
         ])
 
       response ->
-        Logger.error(["retry: got response with status #{response.status}, ", message])
+        Logger.log(level, ["retry: got response with status #{response.status}, ", message])
     end
   end
 

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -826,8 +826,7 @@ defmodule Req.StepsTest do
     request = Req.new(adapter: adapter, url: c.url, retry_delay: 1)
     log = ExUnit.CaptureLog.capture_log(fn -> Req.get!(request) end)
 
-    assert log =~
-             "[error] retry: got response with status 500, will retry in 1ms, 3 attempts lef"
+    assert log =~ "[error]"
   end
 
   @tag :capture_log
@@ -850,7 +849,7 @@ defmodule Req.StepsTest do
 
     request = Req.new(adapter: adapter, url: c.url, retry_delay: 1, retry_log_level: :info)
     log = ExUnit.CaptureLog.capture_log(fn -> Req.get!(request) end)
-    assert log =~ "[info] retry: got response with status 500, will retry in 1ms, 3 attempts lef"
+    assert log =~ "[info]"
   end
 
   @tag :capture_log

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -827,7 +827,7 @@ defmodule Req.StepsTest do
     log = ExUnit.CaptureLog.capture_log(fn -> Req.get!(request) end)
 
     assert log =~
-             "[warning] retry: got response with status 500, will retry in 1ms, 3 attempts lef"
+             "[error] retry: got response with status 500, will retry in 1ms, 3 attempts lef"
   end
 
   @tag :capture_log

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -826,7 +826,10 @@ defmodule Req.StepsTest do
     request = Req.new(adapter: adapter, url: c.url, retry_delay: 1)
     log = ExUnit.CaptureLog.capture_log(fn -> Req.get!(request) end)
 
-    assert log =~ "[error]"
+    assert String.match?(
+             log,
+             ~r/\[error\][[:blank:]]+retry: got response with status 500, will retry in 1ms, 3 attempts left/u
+           )
   end
 
   @tag :capture_log
@@ -849,7 +852,11 @@ defmodule Req.StepsTest do
 
     request = Req.new(adapter: adapter, url: c.url, retry_delay: 1, retry_log_level: :info)
     log = ExUnit.CaptureLog.capture_log(fn -> Req.get!(request) end)
-    assert log =~ "[info]"
+
+    assert String.match?(
+             log,
+             ~r/\[info\][[:blank:]]+retry: got response with status 500, will retry in 1ms, 3 attempts left/u
+           )
   end
 
   @tag :capture_log

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -806,6 +806,77 @@ defmodule Req.StepsTest do
   end
 
   @tag :capture_log
+  test "retry: default log_level", c do
+    adapter = fn request ->
+      request = Req.Request.update_private(request, :attempt, 0, &(&1 + 1))
+      attempt = request.private.attempt
+
+      response =
+        case attempt do
+          0 ->
+            Req.Response.new(status: 500, body: "oops")
+
+          1 ->
+            Req.Response.new(status: 200, body: "ok")
+        end
+
+      {request, response}
+    end
+
+    request = Req.new(adapter: adapter, url: c.url, retry_delay: 1)
+    log = ExUnit.CaptureLog.capture_log(fn -> Req.get!(request) end)
+
+    assert log =~
+             "[warning] retry: got response with status 500, will retry in 1ms, 3 attempts lef"
+  end
+
+  @tag :capture_log
+  test "retry: custom log_level", c do
+    adapter = fn request ->
+      request = Req.Request.update_private(request, :attempt, 0, &(&1 + 1))
+      attempt = request.private.attempt
+
+      response =
+        case attempt do
+          0 ->
+            Req.Response.new(status: 500, body: "oops")
+
+          1 ->
+            Req.Response.new(status: 200, body: "ok")
+        end
+
+      {request, response}
+    end
+
+    request = Req.new(adapter: adapter, url: c.url, retry_delay: 1, retry_log_level: :info)
+    log = ExUnit.CaptureLog.capture_log(fn -> Req.get!(request) end)
+    assert log =~ "[info] retry: got response with status 500, will retry in 1ms, 3 attempts lef"
+  end
+
+  @tag :capture_log
+  test "retry: logging disabled", c do
+    adapter = fn request ->
+      request = Req.Request.update_private(request, :attempt, 0, &(&1 + 1))
+      attempt = request.private.attempt
+
+      response =
+        case attempt do
+          0 ->
+            Req.Response.new(status: 500, body: "oops")
+
+          1 ->
+            Req.Response.new(status: 200, body: "ok")
+        end
+
+      {request, response}
+    end
+
+    request = Req.new(adapter: adapter, url: c.url, retry_delay: 1, retry_log_level: false)
+    log = ExUnit.CaptureLog.capture_log(fn -> Req.get!(request) end)
+    assert log == ""
+  end
+
+  @tag :capture_log
   @tag timeout: 1000
   test "retry: retry-after" do
     adapter = fn request ->


### PR DESCRIPTION
Also, allows `false` to disable logging of retry messages.