### PR TITLE
Avoid assuming NaiveDateTime is GMT

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -655,7 +655,7 @@ defmodule Req do
           in both HTTP/1.1 and HTTP/2, it is recommended for header keys to be in
           lowercase, to avoid sending duplicate keys in a request.
 
-        * `NaiveDateTime` and `DateTime` header values are encoded as "HTTP date". Otherwise,
+        * `DateTime` header values are encoded as "HTTP date". Otherwise,
           the header value is encoded with `String.Chars.to_string/1`.
 
       If you set `:headers` options both in `Req.new/1` and `request/2`, the header lists are merged.
@@ -934,9 +934,6 @@ defmodule Req do
 
       value =
         case value do
-          %NaiveDateTime{} = naive_datetime ->
-            Req.Steps.format_http_datetime(naive_datetime)
-
           %DateTime{} = datetime ->
             datetime |> DateTime.shift_zone!("Etc/UTC") |> Req.Steps.format_http_datetime()
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -460,8 +460,8 @@ defmodule Req.Steps do
   defp put_if_modified_since(request, cache_path) do
     case File.stat(cache_path) do
       {:ok, stat} ->
-        datetime = stat.mtime |> NaiveDateTime.from_erl!() |> format_http_datetime()
-        Req.Request.put_new_header(request, "if-modified-since", datetime)
+        http_datetime_string = stat.mtime |> NaiveDateTime.from_erl!() |> DateTime.from_naive!("Etc/UTC") |> format_http_datetime()
+        Req.Request.put_new_header(request, "if-modified-since", http_datetime_string)
 
       _ ->
         request

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -460,7 +460,11 @@ defmodule Req.Steps do
   defp put_if_modified_since(request, cache_path) do
     case File.stat(cache_path) do
       {:ok, stat} ->
-        http_datetime_string = stat.mtime |> NaiveDateTime.from_erl!() |> DateTime.from_naive!("Etc/UTC") |> format_http_datetime()
+        http_datetime_string =
+          stat.mtime
+          |> NaiveDateTime.from_erl!()
+          |> DateTime.from_naive!("Etc/UTC")
+          |> format_http_datetime()
         Req.Request.put_new_header(request, "if-modified-since", http_datetime_string)
 
       _ ->

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -465,6 +465,7 @@ defmodule Req.Steps do
           |> NaiveDateTime.from_erl!()
           |> DateTime.from_naive!("Etc/UTC")
           |> format_http_datetime()
+
         Req.Request.put_new_header(request, "if-modified-since", http_datetime_string)
 
       _ ->


### PR DESCRIPTION
Hi,

This is a nice library, thank you.

Here's a PR with the intent of avoiding bugs: Removing the automatic upgrading of `NaiveDateTime` to GMT.

In this case a `NaiveDateTime` is silently "upgraded" to be GMT even though we have no idea if that's true or not.

If a developer has a `NaiveDateTime` that the developer is sure is UTC, it is trivial to call `DateTime.from_naive!(naive, "Etc/UTC")`. However libraries shouldn't assume the UTC offset since it can lead to bugs. The reason that the `NaiveDateTime` type exists is for when we don't know the timezone. Libraries should not assume the time zone offset of `NaiveDateTime`.

This is consistent with the standard library where if you call `DateTime.from_iso8601("2023-04-18 06:16:28.609427")` you get an error because the offset is missing from the string. And why `DateTime.to_unix/1` does not accept `NaiveDateTime`. The `DateTime.to_unix/1` function is in `DateTime` rather than `NaiveDateTime` because unix timestamps are UTC by definition and `NaiveDateTime` does not contain UTC offsets. The same goes for HTTP datetimes.
