### PR TITLE
[Proposal] Allow `:finch_request` to perform the underlying request

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -85,7 +85,6 @@ defmodule Req do
           :plug,
           :finch,
           :finch_request,
-          :finch_exec_request,
           :connect_options,
           :receive_timeout,
           :pool_timeout,

--- a/lib/req.ex
+++ b/lib/req.ex
@@ -85,6 +85,7 @@ defmodule Req do
           :plug,
           :finch,
           :finch_request,
+          :finch_exec_request,
           :connect_options,
           :receive_timeout,
           :pool_timeout,

--- a/lib/req/response.ex
+++ b/lib/req/response.ex
@@ -30,8 +30,13 @@ defmodule Req.Response do
   @doc """
   Returns a new response.
   """
-  @spec new(options :: keyword()) :: t()
-  def new(options \\ []) do
+  @spec new(options :: keyword() | map() | struct()) :: t()
+  def new(options \\ [])
+
+  def new(options) when is_list(options), do: new(Map.new(options))
+
+  def new(options) do
+    options = Map.take(options, [:status, :headers, :body])
     struct!(__MODULE__, options)
   end
 

--- a/lib/req/response.ex
+++ b/lib/req/response.ex
@@ -29,6 +29,18 @@ defmodule Req.Response do
 
   @doc """
   Returns a new response.
+
+  Expects a keyword list, map, or struct containing the response keys.
+
+  ## Example
+
+      iex> Req.Response.new(status: 200, body: "body")
+      %Req.Response{status: 200, headers: [], body: "body"}
+
+      iex> finch_response = %Finch.Response{status: 200}
+      iex> Req.Response.new(finch_response)
+      %Req.Response{status: 200, headers: [], body: ""}
+
   """
   @spec new(options :: keyword() | map() | struct()) :: t()
   def new(options \\ [])

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -544,12 +544,12 @@ defmodule Req.Steps do
 
     * `:unix_socket` - if set, connect through the given UNIX domain socket
 
-    * `:finch_request` - a function to modify the built Finch request before execution. This function takes
-      a Finch request and returns a Finch request. If not provided, the Finch request will not be modified.
-
-    * `:finch_exec_request` - a function that executes the request. This function takes a Finch request,
-      a Finch name, and Finch options and returns a `%Req.Response{}` struct indicating success, or an
-      exception indicating an error. Defaults to using a function wrapping `Finch.request/3`.
+    * `:finch_request` - a function that takes 3 arguments and executes the request. It must accept
+      a Finch request, a Finch name, and Finch options, and return a `%Req.Response{}` struct
+      indicating success or an exception indicating an error. Defaults to using a function wrapping
+      `Finch.request/3`. (Deprecation warning: this function can also take 1 argument, in which
+      case it should accept and return a Finch request, but this usage will be removed in a future
+      release.)
 
   ## Examples
 
@@ -580,12 +580,11 @@ defmodule Req.Steps do
     finch_request =
       Finch.build(request.method, request.url, request.headers, request.body)
       |> Map.replace!(:unix_socket, request.options[:unix_socket])
-      |> update_finch_request(request)
 
     finch_options =
       request.options |> Map.take([:receive_timeout, :pool_timeout]) |> Enum.to_list()
 
-    response_or_error = exec_finch_request(finch_request, finch_name, finch_options, request)
+    response_or_error = run_finch_request(finch_request, finch_name, finch_options, request)
 
     {request, response_or_error}
   end
@@ -664,30 +663,28 @@ defmodule Req.Steps do
     end
   end
 
-  defp update_finch_request(finch_request, request) do
+  defp run_finch_request(finch_request, finch_name, finch_options, request) do
     case Map.fetch(request.options, :finch_request) do
-      {:ok, fun} -> fun.(finch_request)
-      :error -> finch_request
+      {:ok, fun} when is_function(fun, 3) ->
+        fun.(finch_request, finch_name, finch_options)
+
+      {:ok, deprecated_fun} when is_function(deprecated_fun, 1) ->
+        IO.warn(
+          ":finch_request fun accepting a single argument is deprecated. " <>
+            "See Req.Steps.run_finch/1 for more information."
+        )
+
+        run_finch_request(deprecated_fun.(finch_request), finch_name, finch_options)
+
+      :error ->
+        run_finch_request(finch_request, finch_name, finch_options)
     end
   end
 
-  defp exec_finch_request(finch_request, finch_name, finch_options, request) do
-    case Map.fetch(request.options, :finch_exec_request) do
-      {:ok, fun} ->
-        fun.(finch_request, finch_name, finch_options)
-
-      :error ->
-        case Finch.request(finch_request, finch_name, finch_options) do
-          {:ok, response} ->
-            %Req.Response{
-              status: response.status,
-              headers: response.headers,
-              body: response.body
-            }
-
-          {:error, exception} ->
-            exception
-        end
+  defp run_finch_request(finch_request, finch_name, finch_options) do
+    case Finch.request(finch_request, finch_name, finch_options) do
+      {:ok, response} -> Req.Response.new(response)
+      {:error, exception} -> exception
     end
   end
 

--- a/test/req/response_test.exs
+++ b/test/req/response_test.exs
@@ -1,4 +1,4 @@
 defmodule Req.ResponseTest do
   use ExUnit.Case, async: true
-  doctest Req.Response, only: [json: 2]
+  doctest Req.Response, except: [get_header: 2, put_header: 3]
 end

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -1201,7 +1201,7 @@ defmodule Req.StepsTest do
     assert Req.request!(plug: plug, json: %{a: 1}).body == "ok"
   end
 
-  test "run_finch: :finch_request", c do
+  test "run_finch: :finch_request with arity 1 (deprecated)", c do
     Bypass.expect(c.bypass, "GET", "/ok", fn conn ->
       Plug.Conn.send_resp(conn, 200, "ok")
     end)
@@ -1213,11 +1213,16 @@ defmodule Req.StepsTest do
       request
     end
 
-    assert Req.get!(c.url <> "/ok", finch_request: fun).body == "ok"
+    warning =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert Req.get!(c.url <> "/ok", finch_request: fun).body == "ok"
+      end)
+
+    assert warning =~ "deprecated"
     assert_received %Finch.Request{}
   end
 
-  test "run_finch: :finch_exec_request", c do
+  test "run_finch: :finch_request", c do
     Bypass.expect(c.bypass, "GET", "/ok", fn conn ->
       Plug.Conn.send_resp(conn, 200, "ok")
     end)
@@ -1227,18 +1232,18 @@ defmodule Req.StepsTest do
     fun = fn finch_request, finch_name, finch_opts ->
       {:ok, resp} = Finch.request(finch_request, finch_name, finch_opts)
       send(pid, resp)
-      %Req.Response{status: resp.status, headers: resp.headers, body: "finch_exec_request"}
+      %Req.Response{status: resp.status, headers: resp.headers, body: "finch_request"}
     end
 
-    assert Req.get!(c.url <> "/ok", finch_exec_request: fun).body == "finch_exec_request"
+    assert Req.get!(c.url <> "/ok", finch_request: fun).body == "finch_request"
     assert_received %Finch.Response{body: "ok"}
   end
 
-  test "run_finch: :finch_exec_request error", c do
+  test "run_finch: :finch_request error", c do
     fun = fn _finch_request, _finch_name, _finch_opts -> %ArgumentError{message: "exec error"} end
 
     assert_raise ArgumentError, "exec error", fn ->
-      Req.get!(c.url, finch_exec_request: fun, retry: :never)
+      Req.get!(c.url, finch_request: fun, retry: :never)
     end
   end
 


### PR DESCRIPTION
Hi there! This is basically a proposal with code: Add a `:finch_exec_request` option to the default Finch adapter in order to enable custom plugins/steps to implement streaming response bodies.

[This recent ChatGPT streaming example](https://github.com/wojtekmach/mix_install_examples/pull/22) got me thinking about how the example could be implemented in Req. Finch provides support for streaming responses with `Finch.stream/5`, but the `run_finch` adapter always calls `Finch.request/3`. One could create their own `run_finch_stream` adapter, but they would be duplicating quite a lot of effort. The idea of this proposal is that an optional `:finch_exec_request` function would be provided with the Finch request, name, and options, and would return either a Req response or an exception.

Using this branch, it's fairly straightforward to write a plugin that allows for streaming responses. [Here's a Livebook notebook](https://gist.github.com/zachallaun/88aed2a0cef0aed6d68dcc7c12531649) showing how it might be done. There are some issues with resource handling (no back pressure, no explicit mechanism to cancel the request), but I believe this still opens up some useful options for plugins.