### PR TITLE
Fix autolink reference for `Req.new/1` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [`Req.request/1`]: https://hexdocs.pm/req/Req.html#request/1
-[`Req.new/1`]:    https://hexdocs.pm/req/Req.html#get!/2
+[`Req.new/1`]:    https://hexdocs.pm/req/Req.html#new/1
 [`Req.get!/2`]:    https://hexdocs.pm/req/Req.html#get!/2
 [`Req.post!/2`]:   https://hexdocs.pm/req/Req.html#post!/2
 [`Req.Request`]:   https://hexdocs.pm/req/Req.Request.html

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [`Req.request/1`]: https://hexdocs.pm/req/Req.html#request/1
-[`Req.new/1`]:    https://hexdocs.pm/req/Req.html#new/1
+[`Req.new/1`]:     https://hexdocs.pm/req/Req.html#new/1
 [`Req.get!/2`]:    https://hexdocs.pm/req/Req.html#get!/2
 [`Req.post!/2`]:   https://hexdocs.pm/req/Req.html#post!/2
 [`Req.Request`]:   https://hexdocs.pm/req/Req.Request.html


### PR DESCRIPTION
Currently the link to `Req.new/1` in the README points to`https://hexdocs.pm/req/Req.html#get!/2`:

![demo-bug](https://github.com/wojtekmach/req/assets/20464770/fb1701ce-f4fb-441b-acc9-896112b1d42d)

This PR is to fix the link reference so people can go to the correct page in HexDocs.