### PR TITLE
URL Encode the Location header when redirecting

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1205,7 +1205,9 @@ defmodule Req.Steps do
   end
 
   defp build_redirect_request(request, response) do
-    {_, location} = List.keyfind(response.headers, "location", 0)
+    location = with {_, location} <- List.keyfind(response.headers, "location", 0) do
+      URI.encode(location)
+    end
 
     log_level = Map.get(request.options, :redirect_log_level, :debug)
     log_redirect(log_level, location)

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -575,6 +575,20 @@ defmodule Req.StepsTest do
            end) =~ "[debug] follow_redirects: redirecting to #{c.url}/ok"
   end
 
+  test "follow_redirects: url encode location", c do
+    Bypass.expect(c.bypass, "GET", "/redirect", fn conn ->
+      redirect(conn, 302, c.url <> "/url encode")
+    end)
+
+    Bypass.expect(c.bypass, "GET", "/url%20encode", fn conn ->
+      Plug.Conn.send_resp(conn, 200, "ok")
+    end)
+
+    assert ExUnit.CaptureLog.capture_log(fn ->
+             assert Req.get!(c.url <> "/redirect").status == 200
+           end) =~ "[debug] follow_redirects: redirecting to #{c.url}/url%20encode"
+  end
+
   test "follow_redirects: relative", c do
     Bypass.expect(c.bypass, "GET", "/redirect", fn conn ->
       location =


### PR DESCRIPTION
Mint will fail with invalid_request_target without this when encountering URLs in Location headers with spaces.