### PR TITLE
Encode path params after applying

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -349,8 +349,13 @@ defmodule Req.Steps do
 
       path ->
         Regex.replace(~r/:([a-zA-Z]{1}[\w_]*)/, path, fn match, key ->
-          to_string(params[String.to_existing_atom(key)] || match)
-          |> URI.encode()
+          case Map.fetch(params, String.to_existing_atom(key)) do
+            {:ok, value} ->
+              value |> to_string() |> URI.encode()
+
+            :error ->
+              match
+          end
         end)
     end)
   end

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -349,12 +349,12 @@ defmodule Req.Steps do
 
       path ->
         Regex.replace(~r/:([a-zA-Z]{1}[\w_]*)/, path, fn match, key ->
-          case Map.fetch(params, String.to_existing_atom(key)) do
-            {:ok, value} ->
-              value |> to_string() |> URI.encode()
-
-            :error ->
+          case params[String.to_existing_atom(key)] do
+            nil ->
               match
+
+            value ->
+              value |> to_string() |> URI.encode()
           end
         end)
     end)

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -350,8 +350,8 @@ defmodule Req.Steps do
       path ->
         Regex.replace(~r/:([a-zA-Z]{1}[\w_]*)/, path, fn match, key ->
           to_string(params[String.to_existing_atom(key)] || match)
+          |> URI.encode()
         end)
-        |> URI.encode()
     end)
   end
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -351,6 +351,7 @@ defmodule Req.Steps do
         Regex.replace(~r/:([a-zA-Z]{1}[\w_]*)/, path, fn match, key ->
           to_string(params[String.to_existing_atom(key)] || match)
         end)
+        |> URI.encode()
     end)
   end
 

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -219,8 +219,8 @@ defmodule Req.StepsTest do
   end
 
   test "put_path_params" do
-    req = Req.new(url: "http://foo/:id", path_params: [id: 1]) |> Req.Request.prepare()
-    assert URI.to_string(req.url) == "http://foo/1"
+    req = Req.new(url: "http://foo/:id", path_params: [id: "abc|def"]) |> Req.Request.prepare()
+    assert URI.to_string(req.url) == "http://foo/abc%7Cdef"
   end
 
   test "put_range" do


### PR DESCRIPTION
I found a situation today where we have params which we want to record unencoded to opentelemetry attributes but results in a path which is not URI encoded. This update will encode the path after application to the template so that the params don't need to be encoded by the user.