### PR TITLE
Delete content-encoding header after decompressing

### DIFF
--- a/lib/req/response.ex
+++ b/lib/req/response.ex
@@ -141,4 +141,33 @@ defmodule Req.Response do
       when is_binary(key) and is_binary(value) do
     %{response | headers: List.keystore(response.headers, key, 0, {key, value})}
   end
+
+  @doc """
+  Deletes the header given by `key`
+
+  All occurences of the header are delete, in case the header is repeated multiple times.
+
+  ## Examples
+
+      iex> response.headers
+      [
+        {"cache-control", "max-age=600"},
+        {"content-type", "text/html"},
+        {"Cache-Control", "no-transform"}
+      ]
+      iex> Req.Response.delete_header(response, "cache-control").headers
+      [{"content-type", "text/html"}]
+
+  """
+  def delete_header(%Req.Response{} = response, key) when is_binary(key) do
+    %Req.Response{
+      response
+      | headers:
+          for(
+            {name, value} <- response.headers,
+            String.downcase(name) != String.downcase(key),
+            do: {name, value}
+          )
+    }
+  end
 end

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -817,6 +817,9 @@ defmodule Req.Steps do
   | zstd          | `:ezstd.decompress/1` (if [ezstd] is installed) |
   | identity      | Returns data as is                              |
 
+  This step updates the following headers to reflect the changes:
+  - `content-legnth` is set to the length of the decompressed body
+
   ## Options
 
     * `:raw` - if set to `true`, disables response body decompression. Defaults to `false`.

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -819,6 +819,7 @@ defmodule Req.Steps do
 
   This step updates the following headers to reflect the changes:
   - `content-length` is set to the length of the decompressed body
+  - `content-encoding` is deleted
 
   ## Options
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -866,6 +866,7 @@ defmodule Req.Steps do
     response =
       %Req.Response{response | body: decompressed_body}
       |> Req.Response.put_header("content-length", decompressed_content_length)
+      |> Req.Response.delete_header("content-encoding")
 
     {request, response}
   end

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -818,7 +818,7 @@ defmodule Req.Steps do
   | identity      | Returns data as is                              |
 
   This step updates the following headers to reflect the changes:
-  - `content-legnth` is set to the length of the decompressed body
+  - `content-length` is set to the length of the decompressed body
 
   ## Options
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -857,7 +857,14 @@ defmodule Req.Steps do
 
   def decompress_body({request, response}) do
     compression_algorithms = get_content_encoding_header(response.headers)
-    {request, update_in(response.body, &decompress_body(&1, compression_algorithms))}
+    decompressed_body = decompress_body(response.body, compression_algorithms)
+    decompressed_content_length = decompressed_body |> byte_size() |> to_string()
+
+    response =
+      %Req.Response{response | body: decompressed_body}
+      |> Req.Response.put_header("content-length", decompressed_content_length)
+
+    {request, response}
   end
 
   defp decompress_body(body, algorithms) do

--- a/test/req/response_test.exs
+++ b/test/req/response_test.exs
@@ -1,4 +1,4 @@
 defmodule Req.ResponseTest do
   use ExUnit.Case, async: true
-  doctest Req.Response, except: [get_header: 2, put_header: 3]
+  doctest Req.Response, except: [get_header: 2, put_header: 3, delete_header: 2]
 end

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -311,8 +311,8 @@ defmodule Req.StepsTest do
       end)
 
       response = Req.get!(c.url)
-
-      assert content_length(response) == byte_size(body)
+      [content_length] = Req.Response.get_header(response, "content-length")
+      assert String.to_integer(content_length) == byte_size(body)
     end
   end
 
@@ -1353,13 +1353,5 @@ defmodule Req.StepsTest do
       end
 
     Plug.Conn.send_resp(conn, status, Jason.encode_to_iodata!(data))
-  end
-
-  defp content_length(response) do
-    {"content-length", content_length_str} = List.keyfind!(response.headers, "content-length", 0)
-
-    {content_length, _remainder} = Integer.parse(content_length_str)
-
-    content_length
   end
 end

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -322,8 +322,7 @@ defmodule Req.StepsTest do
         |> Plug.Conn.send_resp(200, :zlib.gzip("foo"))
       end)
 
-      response = Req.get!(c.url).body
-      refute List.keyfind(response.headers, "content-encoding", 0)
+      refute List.keyfind(Req.get!(c.url).headers, "content-encoding", 0)
     end
   end
 

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -296,6 +296,24 @@ defmodule Req.StepsTest do
 
       assert Req.get!(c.url).body == "foo"
     end
+
+    test "recalculate content-length when decompressing", c do
+      body = "foo"
+      gzipped_body = :zlib.gzip(body)
+
+      assert byte_size(body) != byte_size(gzipped_body)
+
+      Bypass.expect(c.bypass, "GET", "/", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-encoding", "x-gzip")
+        |> Plug.Conn.put_resp_header("content-length", gzipped_body |> byte_size() |> to_string())
+        |> Plug.Conn.send_resp(200, gzipped_body)
+      end)
+
+      response = Req.get!(c.url)
+
+      assert content_length(response) == byte_size(body)
+    end
   end
 
   describe "output" do
@@ -1335,5 +1353,13 @@ defmodule Req.StepsTest do
       end
 
     Plug.Conn.send_resp(conn, status, Jason.encode_to_iodata!(data))
+  end
+
+  defp content_length(response) do
+    {"content-length", content_length_str} = List.keyfind!(response.headers, "content-length", 0)
+
+    {content_length, _remainder} = Integer.parse(content_length_str)
+
+    content_length
   end
 end

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -314,6 +314,17 @@ defmodule Req.StepsTest do
       [content_length] = Req.Response.get_header(response, "content-length")
       assert String.to_integer(content_length) == byte_size(body)
     end
+
+    test "content-encoding header is deleted after decompress", c do
+      Bypass.expect(c.bypass, "GET", "/", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-encoding", "x-gzip")
+        |> Plug.Conn.send_resp(200, :zlib.gzip("foo"))
+      end)
+
+      response = Req.get!(c.url).body
+      refute List.keyfind(response.headers, "content-encoding", 0)
+    end
   end
 
   describe "output" do


### PR DESCRIPTION
When a response is decompressed, we should remove the content-encoding header because other downstream steps may find themselves confused by an erroneous `%Req.Response{}` struct where:
- the body is uncompressed
- but the `content-encoding` header say otherwise