### PR TITLE
Set content-length when decompressing

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -861,6 +861,9 @@ defmodule Req.Steps do
   | zstd          | `:ezstd.decompress/1` (if [ezstd] is installed) |
   | _other_       | Returns data as is                              |
 
+  This step updates the following headers to reflect the changes:
+  - `content-legnth` is set to the length of the decompressed body
+
   ## Options
 
     * `:raw` - if set to `true`, disables response body decompression. Defaults to `false`.

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -862,7 +862,7 @@ defmodule Req.Steps do
   | _other_       | Returns data as is                              |
 
   This step updates the following headers to reflect the changes:
-  - `content-legnth` is set to the length of the decompressed body
+  - `content-length` is set to the length of the decompressed body
 
   ## Options
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -902,7 +902,14 @@ defmodule Req.Steps do
       {request, response}
     else
       compression_algorithms = get_content_encoding_header(response.headers)
-      {request, update_in(response.body, &decompress_body(&1, compression_algorithms))}
+      decompressed_body = decompress_body(response.body, compression_algorithms)
+      decompressed_content_length = decompressed_body |> byte_size() |> to_string()
+
+      response =
+        %Req.Response{response | body: decompressed_body}
+        |> Req.Response.put_header("content-length", decompressed_content_length)
+
+      {request, response}
     end
   end
 

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -385,8 +385,8 @@ defmodule Req.StepsTest do
       end)
 
       response = Req.get!(c.url)
-
-      assert content_length(response) == byte_size(body)
+      [content_length] = Req.Response.get_header(response, "content-length")
+      assert String.to_integer(content_length) == byte_size(body)
     end
   end
 
@@ -1512,13 +1512,5 @@ defmodule Req.StepsTest do
       end
 
     Plug.Conn.send_resp(conn, status, Jason.encode_to_iodata!(data))
-  end
-
-  defp content_length(response) do
-    {"content-length", content_length_str} = List.keyfind!(response.headers, "content-length", 0)
-
-    {content_length, _remainder} = Integer.parse(content_length_str)
-
-    content_length
   end
 end

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -370,6 +370,24 @@ defmodule Req.StepsTest do
 
       assert Req.head!(c.url).body == ""
     end
+
+    test "recalculate content-length when decompressing", c do
+      body = "foo"
+      gzipped_body = :zlib.gzip(body)
+
+      assert byte_size(body) != byte_size(gzipped_body)
+
+      Bypass.expect(c.bypass, "GET", "/", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-encoding", "gzip")
+        |> Plug.Conn.put_resp_header("content-length", gzipped_body |> byte_size() |> to_string())
+        |> Plug.Conn.send_resp(200, gzipped_body)
+      end)
+
+      response = Req.get!(c.url)
+
+      assert content_length(response) == byte_size(body)
+    end
   end
 
   describe "output" do
@@ -1494,5 +1512,13 @@ defmodule Req.StepsTest do
       end
 
     Plug.Conn.send_resp(conn, status, Jason.encode_to_iodata!(data))
+  end
+
+  defp content_length(response) do
+    {"content-length", content_length_str} = List.keyfind!(response.headers, "content-length", 0)
+
+    {content_length, _remainder} = Integer.parse(content_length_str)
+
+    content_length
   end
 end


### PR DESCRIPTION
When decompressing, the `content-length` is left unchanged. As a consequence, it's no longer matches the body's length, and could confuse other steps or users.

This PR automatically sets `content-length` after decompression.

It could be discussed if it's worth adding it if it wasn't there in the first place. I'd argue it cannot hurt, and proxies routinely do this. Not only it doesn't hurt, but it can help a client know when the response has been fully recieved (should `Req` be used in a reverse-proxy one day) especially when using multiplexing (`Connection: keep-alive`).

Not sure if we should update the documentation to notice users about these changes.