### PR TITLE
Fix typespecs for some functions

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -383,6 +383,12 @@ defmodule Req do
   @doc """
   Makes a GET request.
 
+  `request` can be one of:
+
+    * a `String` or `URI`;
+    * a `Keyword` options;
+    * a `Req.Request` struct
+
   See `new/1` for a list of available options.
 
   ## Examples
@@ -407,7 +413,7 @@ defmodule Req do
       200
 
   """
-  @spec get(url() | Req.Request.t(), options :: keyword()) ::
+  @spec get(url() | keyword() | Req.Request.t(), options :: keyword()) ::
           {:ok, Req.Response.t()} | {:error, Exception.t()}
   def get(request, options \\ [])
 
@@ -591,7 +597,7 @@ defmodule Req do
       iex> resp.body["data"]
       "hello!"
   """
-  @spec post(url() | Req.Request.t(), options :: keyword()) ::
+  @spec post(url() | keyword() | Req.Request.t(), options :: keyword()) ::
           {:ok, Req.Response.t()} | {:error, Exception.t()}
   def post(request, options \\ [])
 
@@ -676,7 +682,7 @@ defmodule Req do
       iex> resp.body["data"]
       "hello!"
   """
-  @spec put(url() | Req.Request.t(), options :: keyword()) ::
+  @spec put(url() | keyword() | Req.Request.t(), options :: keyword()) ::
           {:ok, Req.Response.t()} | {:error, Exception.t()}
   def put(request, options \\ [])
 
@@ -761,7 +767,7 @@ defmodule Req do
       iex> resp.body["data"]
       "hello!"
   """
-  @spec patch(url() | Req.Request.t(), options :: keyword()) ::
+  @spec patch(url() | keyword() | Req.Request.t(), options :: keyword()) ::
           {:ok, Req.Response.t()} | {:error, Exception.t()}
   def patch(url_or_request, options \\ [])
 


### PR DESCRIPTION
Hi, I was using this library and dialyzer started to complain:

```dialyzer
lib/dummy/dummy.ex:94:call
The function call will not succeed.

Req.put([
  {:body, binary()} | {:headers, [{<<_::72>>, _}, ...]} | {:url, <<_::8, _::size(1)>>},
  ...
])

will never return since the 1st arguments differ
from the success typing arguments:

(
  binary()
  | %{
      :__struct__ => Req.Request | URI,
      :adapter => (... -> any),
      :authority => URI.authority(),
      :body =>
        nil
        | binary()
        | maybe_improper_list(
            binary() | maybe_improper_list(any(), binary() | []) | byte(),
            binary() | []
          ),
      :current_request_steps => _,
...
```

So I took a look at the source code, and saw that for some functions the `keyword()` type was missing in the typespec, while all those functions had a clause to handle keyword lists, and the docs clearly said a keyword list was accepted.

So I added them, and also made the docs for `get/2` consistent with the rest.