### PR TITLE
Use maps for request header examples

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -113,7 +113,7 @@ defmodule Req do
 
     * `:url` - the request URL.
 
-    * `:headers` - the request headers as a key-value map or key-value tuple list. 
+    * `:headers` - the request headers as a `{key, value}` enumerable (e.g. map, keyword list). 
 
       The header names should be downcased.
 

--- a/lib/req.ex
+++ b/lib/req.ex
@@ -113,7 +113,9 @@ defmodule Req do
 
     * `:url` - the request URL.
 
-    * `:headers` - the request headers. The header names should be downcased.
+    * `:headers` - the request headers as a key-value map or key-value tuple list. 
+
+      The header names should be downcased.
 
       The headers are automatically encoded using these rules:
 
@@ -407,15 +409,15 @@ defmodule Req do
 
   Passing `:headers` will automatically encode and merge them:
 
-      iex> req = Req.new(headers: [point_x: 1])
-      iex> req = Req.update(req, headers: [point_y: 2])
+      iex> req = Req.new(headers: %{point_x: 1})
+      iex> req = Req.update(req, headers: %{point_y: 2})
       iex> req.headers
       %{"point-x" => ["1"], "point-y" => ["2"]}
 
   The same header names are overwritten however:
 
-      iex> req = Req.new(headers: [authorization: "bearer foo"])
-      iex> req = Req.update(req, headers: [authorization: "bearer bar"])
+      iex> req = Req.new(headers: %{authorization: "bearer foo"})
+      iex> req = Req.update(req, headers: %{authorization: "bearer bar"})
       iex> req.headers
       %{"authorization" => ["bearer bar"]}
 


### PR DESCRIPTION
As discussed here: 

https://github.com/wojtekmach/req/pull/224#issuecomment-1705159795

As a couple of `iex` tests learned my that `headers: %{"key" => "value"}` maps are also accepted and merged correctly (i.e. no need to explicitly wrap `"value"` in `["value"`]), using maps in the examples felt like an improvement, as they are closer to the `%Req.Request{}` typespec.