### PR TITLE
Add `:finch_private` option to put into Finch.Request

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -293,6 +293,9 @@ defmodule Req do
 
     * `:unix_socket` - if set, connect through the given UNIX domain socket.
 
+    * `:finch_private` - a map or keyword list of private metadata to add to the Finch request. May be useful
+      for adding custom data when handling telemetry with `Finch.Telemetry`.
+
     * `:finch_request` - a function that executes the Finch request, defaults to using `Finch.request/3`.
 
   ## Examples
@@ -350,6 +353,7 @@ defmodule Req do
           :plug,
           :finch,
           :finch_request,
+          :finch_private,
           :connect_options,
           :inet6,
           :receive_timeout,


### PR DESCRIPTION
Resolve #251 

This adds the `:finch_private` option which will allow adding private metadata to the Finch request when built so it travels through Req's finch adapter. This is helpful for putting custom metadata in for handling in `:telemetry` event handlers.