### PR TITLE
Add step execution Telemetry

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,8 @@ defmodule Req.MixProject do
       {:brotli, "~> 0.3.1", optional: true},
       {:ezstd, "~> 1.0", optional: true},
       {:bypass, "~> 2.1", only: :test},
-      {:ex_doc, ">= 0.0.0", only: :docs}
+      {:ex_doc, ">= 0.0.0", only: :docs},
+      {:telemetry, "~> 0.4 or ~> 1.0"}
     ]
   end
 


### PR DESCRIPTION
When debugging a latency increase in our Req clients we found it extremely useful to have the ability to create otel spans around Req step execution. We gain a similar level of granularity by attaching to Finch telemetry, but this helps us visualize everything that is happening in a request not just the connection pool and network bits.

What do you think?