### PR TITLE
Add option to keep cookies between redirected requests

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -113,7 +113,7 @@ defmodule Req do
 
     * `:url` - the request URL.
 
-    * `:headers` - the request headers as a `{key, value}` enumerable (e.g. map, keyword list). 
+    * `:headers` - the request headers as a `{key, value}` enumerable (e.g. map, keyword list).
 
       The header names should be downcased.
 
@@ -218,6 +218,8 @@ defmodule Req do
       will be sent to any host.
 
     * `:max_redirects` - the maximum number of redirects, defaults to `10`.
+
+    * `:keep_cookie` - if set to `true`, transmits server cookies on redirected requests. Defaults to `false`.
 
   Retry options ([`retry`](`Req.Steps.retry/1`) step):
 
@@ -345,6 +347,7 @@ defmodule Req do
           :redirect,
           :redirect_trusted,
           :redirect_log_level,
+          :keep_cookie,
           :max_redirects,
           :retry,
           :retry_delay,


### PR DESCRIPTION
Not sure if this is a common case, but I had to query a server which used basic auth for the initial authentication, but then sets a cookie for the session and redirects to the wanted resource.  

This PR adds an option (`:keep_cookie`) to use the cookie received from the server via the `set-cookie` header for subsequent (redirected) requests.