### PR TITLE
Fix incorrect `put_header` doctest (& re-enable the doctest)

### DIFF
--- a/lib/req/response.ex
+++ b/lib/req/response.ex
@@ -192,7 +192,7 @@ defmodule Req.Response do
 
   ## Examples
 
-      iex> resp = Req.Response.put_header(resp, "content-type", "application/json")
+      iex> resp = Req.Response.put_header(%Req.Response{}, "content-type", "application/json")
       iex> resp.headers
       [{"content-type", "application/json"}]
   """

--- a/lib/req/response.ex
+++ b/lib/req/response.ex
@@ -194,7 +194,7 @@ defmodule Req.Response do
 
       iex> resp = Req.Response.put_header(%Req.Response{}, "content-type", "application/json")
       iex> resp.headers
-      [{"content-type", "application/json"}]
+      %{"content-type" => ["application/json"]}
   """
   @spec put_header(t(), binary(), binary()) :: t()
   if Req.MixProject.legacy_headers_as_lists?() do

--- a/test/req/response_test.exs
+++ b/test/req/response_test.exs
@@ -1,4 +1,4 @@
 defmodule Req.ResponseTest do
   use ExUnit.Case, async: true
-  doctest Req.Response, except: [get_header: 2, put_header: 3, delete_header: 2]
+  doctest Req.Response, except: [get_header: 2, delete_header: 2]
 end


### PR DESCRIPTION
I went through the doc during a work task and found that the `put_header` doc was still referencing "non-map" (pre 0.4) headers format.

Instead of just fixing it, I preferred to understand why the test was not failing in the first place, discovered that it was disabled, re-enabled it and fixed it.

Unsure if I missed something (re: `Req.MixProject.legacy_headers_as_lists?` in particular), or other motivations which may have lead to that specific doctest being disabled, so feel free to adapt!