### PR TITLE
Add support for deflate decompression

### DIFF
--- a/test/req/request_test.exs
+++ b/test/req/request_test.exs
@@ -269,7 +269,7 @@ defmodule Req.RequestTest do
     else
       assert %{
                "user-agent" => ["req/" <> _],
-               "accept-encoding" => ["zstd, br, gzip"],
+               "accept-encoding" => ["zstd, br, gzip, deflate"],
                "authorization" => [^authorization]
              } = request.headers
     end


### PR DESCRIPTION
EDIT: Oh! I see this was [intentionally removed](https://github.com/wojtekmach/req/issues/215#issuecomment-1675461292) in the past. Feel free to close!

This adds support for responses that were compressed using the `deflate` algorithm.

As best I can tell, this isn't terribly common for servers to send in the wild—in my own usage of Req for scraping public sites, I see gzip and Brotli way, way more frequently. However, I think it's useful to have in Req for the sake of having decompression support that matches real browsers; Safari, Firefox, and Chrome each send an `Accept-Encoding` header of `gzip, deflate, br`.