### PR TITLE
Handle content-type when there is more than one in the header list

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1596,7 +1596,7 @@ defmodule Req.Steps do
 
   defp format(request, response) do
     case Req.Response.get_header(response, "content-type") do
-      [content_type] ->
+      [content_type | _] ->
         # TODO: remove ` || ` when we require Elixir v1.13
         path = request.url.path || ""
 

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -539,6 +539,20 @@ defmodule Req.StepsTest do
   end
 
   describe "decode_body" do
+    test "multiple types", c do
+      Bypass.expect(c.bypass, "GET", "/", fn conn ->
+        headers =
+          [
+            {"content-type", "text/plain"},
+            {"content-type", "text/plain; charset=utf-8"}
+          ] ++ conn.resp_headers
+
+        Plug.Conn.send_resp(%{conn | resp_headers: headers}, 200, "ok")
+      end)
+
+      assert Req.get!(c.url).body == "ok"
+    end
+
     test "json", c do
       Bypass.expect(c.bypass, "GET", "/", fn conn ->
         json(conn, 200, %{a: 1})


### PR DESCRIPTION
Fixes #291

Remote may return multiple content-types in a list.  However, match is only present for a single entry.  For now, select the first content-type in the list as the format.