### PR TITLE
Expose async request functionality

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -60,7 +60,7 @@ defmodule Req do
       iex> resp.body
       %IO.Stream{}
 
-  Stream response body to caller:
+  Stream response body to the calling process:
 
       iex> {req, resp} = Req.async_request!("http://httpbin.org/stream/2")
       iex> resp.status


### PR DESCRIPTION
With Finch 0.17 out, we can begin to expose `async_request/2`, `async_request!/2`, `parse_message/2`, and `cancel_async_request/1` in the public API. This PR exposes these functions in the documentation.

See https://github.com/wojtekmach/req/issues/195 for context.