### PR TITLE
Fix typo in Req.Test docs

### DIFF
--- a/lib/req/test.ex
+++ b/lib/req/test.ex
@@ -55,7 +55,7 @@ defmodule Req.Test do
 
   And tests:
 
-      # config/runtime.exs
+      # config/test.exs
       config :myapp, weather_req_options: [
         plug: {Req.Test, MyApp.Weather}
       ]


### PR DESCRIPTION
Clarifies the second example should be `config/test.exs`