### PR TITLE
Use Req.Request.halt/1 and return redirect exception instead of raising on "too many redirects"

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1923,8 +1923,8 @@ defmodule Req.Steps do
     * `:redirect_log_level` - the log level to emit redirect logs at. Can also be set
       to `false` to disable logging these messages. Defaults to `:debug`.
 
-    * `:max_redirects` - the maximum number of redirects, defaults to `10`.
-      If the limit is reached, an error is raised.
+    * `:max_redirects` - the maximum number of redirects, defaults to `10`. If the
+    limit is reached, the pipeline is halted and an exception struct is returned.
 
   ## Examples
 
@@ -1977,7 +1977,7 @@ defmodule Req.Steps do
           {_, result} = Req.Request.run(request)
           {Req.Request.halt(request), result}
         else
-          raise "too many redirects (#{max_redirects})"
+          {Req.Request.halt(request), %Req.TooManyRedirectsError{max_redirects: max_redirects}}
         end
 
       true ->

--- a/lib/req/too_many_redirects_error.ex
+++ b/lib/req/too_many_redirects_error.ex
@@ -1,0 +1,7 @@
+defmodule Req.TooManyRedirectsError do
+  defexception [:max_redirects]
+
+  def message(%{max_redirects: max_redirects}) do
+    "too many redirects (#{max_redirects})"
+  end
+end

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -1063,7 +1063,7 @@ defmodule Req.StepsTest do
 
       captured_log =
         ExUnit.CaptureLog.capture_log(fn ->
-          assert_raise RuntimeError, "too many redirects (3)", fn ->
+          assert_raise Req.TooManyRedirectsError, "too many redirects (3)", fn ->
             Req.get!(c.url, max_redirects: 3)
           end
         end)


### PR DESCRIPTION
Currently, the included `redirect` step raises an exception with a message when the maximum number of redirects is reached.  This change modifies the existing raise behavior to instead use the halt and return exception behavior used by other steps in the pipeline.