### PR TITLE
Add Req.Test.expect/3

### DIFF
--- a/lib/req/test.ex
+++ b/lib/req/test.ex
@@ -329,9 +329,14 @@ defmodule Req.Test do
   """
   @spec stub(stub(), term()) :: :ok | {:error, Exception.t()}
   def stub(stub_name, value) do
-    NimbleOwnership.get_and_update(@ownership, self(), stub_name, fn map_or_nil ->
+    result = NimbleOwnership.get_and_update(@ownership, self(), stub_name, fn map_or_nil ->
       {:ok, put_in(map_or_nil || %{}, [:stub], value)}
     end)
+
+    case result do
+      {:ok, :ok} -> :ok
+      {:error, error} -> {:error, error}
+    end
   end
 
   @doc """
@@ -354,7 +359,7 @@ defmodule Req.Test do
 
   """
   @doc since: "0.4.15"
-  @spec expect(atom(), pos_integer(), term()) :: term()
+  @spec expect(stub(), pos_integer(), term()) :: term()
   def expect(stub_name, n \\ 1, value) when is_integer(n) and n > 0 do
     values = List.duplicate(value, n)
 

--- a/lib/req/test.ex
+++ b/lib/req/test.ex
@@ -329,9 +329,10 @@ defmodule Req.Test do
   """
   @spec stub(stub(), term()) :: :ok | {:error, Exception.t()}
   def stub(stub_name, value) do
-    result = NimbleOwnership.get_and_update(@ownership, self(), stub_name, fn map_or_nil ->
-      {:ok, put_in(map_or_nil || %{}, [:stub], value)}
-    end)
+    result =
+      NimbleOwnership.get_and_update(@ownership, self(), stub_name, fn map_or_nil ->
+        {:ok, put_in(map_or_nil || %{}, [:stub], value)}
+      end)
 
     case result do
       {:ok, :ok} -> :ok

--- a/test/req/test_test.exs
+++ b/test/req/test_test.exs
@@ -22,6 +22,27 @@ defmodule Req.TestTest do
     assert Req.Test.stub(:foo) == 2
   end
 
+  describe "expect/3" do
+    test "works in the normal expectation-based way" do
+      Req.Test.expect(:foo, 2, 1)
+      assert Req.Test.stub(:foo) == 1
+      assert Req.Test.stub(:foo) == 1
+
+      assert_raise RuntimeError, "no stub or expectations for :foo", fn ->
+        Req.Test.stub(:foo)
+      end
+    end
+
+    test "works with the default expected count of 1" do
+      Req.Test.expect(:foo_default, 1)
+      assert Req.Test.stub(:foo_default) == 1
+
+      assert_raise RuntimeError, "no stub or expectations for :foo_default", fn ->
+        assert Req.Test.stub(:foo_default)
+      end
+    end
+  end
+
   describe "plug" do
     test "function" do
       Req.Test.stub(:foo, fn conn ->


### PR DESCRIPTION
@wojtekmach I think this makes sense in the optics of tests and stubs. I have found myself doing a lot of `send(test_pid, ...)` to ensure that everything gets called and in the right order. This helps a lot with that, since it introduces ordering. We'd need the usual `verify` suspects, but I'll only spend time on those if you think this change is good 😄 