### PR TITLE
Normalize URI before redirect in order to avoid :badarg failure from nil port in URI

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1964,7 +1964,10 @@ defmodule Req.Steps do
           request.options[:redirect_trusted]
       end
 
-    location_url = URI.merge(request.url, URI.parse(location))
+    location_url =
+      request.url
+      |> URI.merge(URI.parse(location))
+      |> normalize_redirect_uri()
 
     request
     # assume put_params step already run so remove :params option so it's not applied again
@@ -1979,6 +1982,10 @@ defmodule Req.Steps do
   defp log_redirect(level, location) do
     Logger.log(level, ["redirecting to ", location])
   end
+
+  defp normalize_redirect_uri(%URI{scheme: "http", port: nil} = uri), do: %URI{uri | port: 80}
+  defp normalize_redirect_uri(%URI{scheme: "https", port: nil} = uri), do: %URI{uri | port: 443}
+  defp normalize_redirect_uri(%URI{} = uri), do: uri
 
   # https://www.rfc-editor.org/rfc/rfc9110#name-301-moved-permanently and 302:
   #


### PR DESCRIPTION
Per #327 - `URI.merge/2` overwrites port attribute with nil during merge with relative redirect URI.  Since `URI.merge/2` correctly follows [RFC 3986 5.2 Relative Resolution](https://www.rfc-editor.org/rfc/rfc3986#section-5.2), a separate normalization step is needed to include [RFC 3986 6.2.3 Scheme-Based Normalization](https://www.rfc-editor.org/rfc/rfc3986#section-6.2.3).

Note: a test was not included since `Bypass` runs on a port other than 80 or 443, and we would explicitly need to test to see if the port will be defaulted to 80/443 (depending on the original URI scheme).  However, we were able to confirm a test watching for `:badarg` exit fails prior to the patch and succeeds after the patch.  This test has been excluded from the PR since it hangs the tests while waiting for a connection timeout in the success case.