### PR TITLE
Fix MatchError during redirect with no location header

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1923,33 +1923,24 @@ defmodule Req.Steps do
           Req.Request.get_option(request, :redirect, true)
       end
 
-    cond do
-      !redirect? ->
-        {request, response}
+    with true <- redirect? && response.status in [301, 302, 303, 307, 308],
+         [location | _] <- Req.Response.get_header(response, "location") do
+      max_redirects = Req.Request.get_option(request, :max_redirects, 10)
+      redirect_count = Req.Request.get_private(request, :req_redirect_count, 0)
 
-      response.status in [301, 302, 303, 307, 308] ->
-        max_redirects = Req.Request.get_option(request, :max_redirects, 10)
-        redirect_count = Req.Request.get_private(request, :req_redirect_count, 0)
+      if redirect_count < max_redirects do
+        request =
+          request
+          |> build_redirect_request(response, location)
+          |> Req.Request.put_private(:req_redirect_count, redirect_count + 1)
 
-        if redirect_count < max_redirects do
-          case Req.Response.get_header(response, "location") do
-            [location | _] ->
-              request =
-                request
-                |> build_redirect_request(response, location)
-                |> Req.Request.put_private(:req_redirect_count, redirect_count + 1)
-
-              {_, result} = Req.Request.run(request)
-              {Req.Request.halt(request), result}
-
-            _ ->
-              {Req.Request.halt(request), response}
-          end
-        else
-          {Req.Request.halt(request), %Req.TooManyRedirectsError{max_redirects: max_redirects}}
-        end
-
-      true ->
+        {_, result} = Req.Request.run(request)
+        {Req.Request.halt(request), result}
+      else
+        {Req.Request.halt(request), %Req.TooManyRedirectsError{max_redirects: max_redirects}}
+      end
+    else
+      _ ->
         {request, response}
     end
   end

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -900,6 +900,14 @@ defmodule Req.StepsTest do
   end
 
   describe "redirect" do
+    test "ignore when :redirect is false", c do
+      Bypass.expect(c.bypass, "GET", "/redirect", fn conn ->
+        redirect(conn, 302, c.url <> "/ok")
+      end)
+
+      assert Req.get!(c.url <> "/redirect", redirect: false).status == 302
+    end
+
     test "absolute", c do
       Bypass.expect(c.bypass, "GET", "/redirect", fn conn ->
         redirect(conn, 302, c.url <> "/ok")

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -980,6 +980,20 @@ defmodule Req.StepsTest do
       end
     end
 
+    test "without location", c do
+      Bypass.expect(c.bypass, "POST", "/redirect", fn conn ->
+        Plug.Conn.send_resp(conn, 303, "")
+      end)
+
+      Bypass.expect(c.bypass, "GET", "/redirect", fn conn ->
+        Plug.Conn.send_resp(conn, 200, "ok")
+      end)
+
+      assert ExUnit.CaptureLog.capture_log(fn ->
+               assert Req.post!(c.url <> "/redirect").status == 200
+             end) =~ "[debug] redirecting to #{c.url}/redirect"
+    end
+
     test "auth same host", c do
       auth_header = {"authorization", "Basic " <> Base.encode64("foo:bar")}
 

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -985,13 +985,7 @@ defmodule Req.StepsTest do
         Plug.Conn.send_resp(conn, 303, "")
       end)
 
-      Bypass.expect(c.bypass, "GET", "/redirect", fn conn ->
-        Plug.Conn.send_resp(conn, 200, "ok")
-      end)
-
-      assert ExUnit.CaptureLog.capture_log(fn ->
-               assert Req.post!(c.url <> "/redirect").status == 200
-             end) =~ "[debug] redirecting to #{c.url}/redirect"
+      assert Req.post!(c.url <> "/redirect").status == 303
     end
 
     test "auth same host", c do


### PR DESCRIPTION
When the redirect step is presented with a response where no `Location` header is specified, a MatchError is thrown from: https://github.com/wojtekmach/req/blob/3852d7e1d0861e7c4a6ae176dba2224d1aaf786e/lib/req/steps.ex#L1990

This patch introduces a function to retrieve and coalesce the `Location` header, avoiding a match error and respecting RFC 2616 section 10.3 (redirects).

Fixes #330