### PR TITLE
Handle decompress_body/1 errors by returning Req.DecompressError

### DIFF
--- a/lib/req/decompress_error.ex
+++ b/lib/req/decompress_error.ex
@@ -3,7 +3,12 @@ defmodule Req.DecompressError do
   Represents an error when decompression fails, returned by `Req.Steps.decompress_body/1`.
   """
 
-  defexception [:format, :data]
+  defexception [:format, :data, :reason]
+
+  @impl true
+  def message(%{format: format, reason: reason}) when not is_nil(reason) do
+    "#{message(%{format: format})}, reason: #{inspect(reason)}"
+  end
 
   @impl true
   def message(%{format: format}) do

--- a/lib/req/decompress_error.ex
+++ b/lib/req/decompress_error.ex
@@ -6,12 +6,12 @@ defmodule Req.DecompressError do
   defexception [:format, :data, :reason]
 
   @impl true
-  def message(%{format: format, reason: reason}) when not is_nil(reason) do
-    "#{message(%{format: format})}, reason: #{inspect(reason)}"
+  def message(%{format: format, reason: nil}) do
+    "#{format} decompression failed"
   end
 
   @impl true
-  def message(%{format: format}) do
-    "decompression failed with format \'#{format}\'"
+  def message(%{format: format, reason: reason}) do
+    "#{format} decompression failed, reason: #{inspect(reason)}"
   end
 end

--- a/lib/req/decompress_error.ex
+++ b/lib/req/decompress_error.ex
@@ -1,0 +1,12 @@
+defmodule Req.DecompressError do
+  @moduledoc """
+  Represents an error when decompression fails, returned by `Req.Steps.decompress_body/1`.
+  """
+
+  defexception [:format, :data]
+
+  @impl true
+  def message(%{format: format}) do
+    "decompression failed with format \'#{format}\'"
+  end
+end

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1698,8 +1698,8 @@ defmodule Req.Steps do
         Logger.debug(":ezstd library not loaded, skipping zstd decompression")
         decompress_body(rest, body, ["zstd" | acc])
 
-      {:error, _reason} ->
-        %Req.DecompressError{format: :zstd, data: body}
+      {:error, reason} ->
+        %Req.DecompressError{format: :zstd, data: body, reason: reason}
     end
   end
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1639,7 +1639,7 @@ defmodule Req.Steps do
 
       case decompress_body(codecs, response.body, []) do
         %Req.DecompressError{} = exception ->
-          {Req.Request.halt(request), exception}
+          {request, exception}
 
         {decompressed_body, unknown_codecs} ->
           response = put_in(response.body, decompressed_body)

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1636,42 +1636,70 @@ defmodule Req.Steps do
       {request, response}
     else
       codecs = compression_algorithms(Req.Response.get_header(response, "content-encoding"))
-      {decompressed_body, unknown_codecs} = decompress_body(codecs, response.body, [])
-      response = put_in(response.body, decompressed_body)
 
-      response =
-        if unknown_codecs == [] do
-          response
-          |> Req.Response.delete_header("content-encoding")
-          |> Req.Response.delete_header("content-length")
-        else
-          Req.Response.put_header(response, "content-encoding", Enum.join(unknown_codecs, ", "))
-        end
+      case decompress_body(codecs, response.body, []) do
+        %Req.DecompressError{} = exception ->
+          {Req.Request.halt(request), exception}
 
-      {request, response}
+        {decompressed_body, unknown_codecs} ->
+          response = put_in(response.body, decompressed_body)
+
+          response =
+            if unknown_codecs == [] do
+              response
+              |> Req.Response.delete_header("content-encoding")
+              |> Req.Response.delete_header("content-length")
+            else
+              Req.Response.put_header(
+                response,
+                "content-encoding",
+                Enum.join(unknown_codecs, ", ")
+              )
+            end
+
+          {request, response}
+      end
     end
   end
 
   defp decompress_body([gzip | rest], body, acc) when gzip in ["gzip", "x-gzip"] do
-    decompress_body(rest, :zlib.gunzip(body), acc)
+    try do
+      decompress_body(rest, :zlib.gunzip(body), acc)
+    rescue
+      e in ErlangError ->
+        if e.original == :data_error do
+          %Req.DecompressError{format: :gzip, data: body}
+        else
+          reraise e, __STACKTRACE__
+        end
+    end
   end
 
   defp decompress_body(["br" | rest], body, acc) do
-    if brotli_loaded?() do
-      {:ok, decompressed} = :brotli.decode(body)
+    with true <- brotli_loaded?(),
+         {:ok, decompressed} <- :brotli.decode(body) do
       decompress_body(rest, decompressed, acc)
     else
-      Logger.debug(":brotli library not loaded, skipping brotli decompression")
-      decompress_body(rest, body, ["br" | acc])
+      false ->
+        Logger.debug(":brotli library not loaded, skipping brotli decompression")
+        decompress_body(rest, body, ["br" | acc])
+
+      :error ->
+        %Req.DecompressError{format: :br, data: body}
     end
   end
 
   defp decompress_body(["zstd" | rest], body, acc) do
-    if ezstd_loaded?() do
-      decompress_body(rest, :ezstd.decompress(body), acc)
+    with true <- ezstd_loaded?(),
+         decompressed when is_binary(decompressed) <- :ezstd.decompress(body) do
+      decompress_body(rest, decompressed, acc)
     else
-      Logger.debug(":ezstd library not loaded, skipping zstd decompression")
-      decompress_body(rest, body, ["zstd" | acc])
+      false ->
+        Logger.debug(":ezstd library not loaded, skipping zstd decompression")
+        decompress_body(rest, body, ["zstd" | acc])
+
+      {:error, _reason} ->
+        %Req.DecompressError{format: :zstd, data: body}
     end
   end
 

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -541,7 +541,7 @@ defmodule Req.StepsTest do
         |> Plug.Conn.send_resp(200, "bad")
       end)
 
-      assert_raise Req.DecompressError, "decompression failed with format 'gzip'", fn ->
+      assert_raise Req.DecompressError, "gzip decompression failed", fn ->
         Req.get!(c.url)
       end
     end
@@ -578,7 +578,7 @@ defmodule Req.StepsTest do
         |> Plug.Conn.send_resp(200, "bad")
       end)
 
-      assert_raise Req.DecompressError, "decompression failed with format 'br'", fn ->
+      assert_raise Req.DecompressError, "br decompression failed", fn ->
         Req.get!(c.url)
       end
     end
@@ -602,7 +602,7 @@ defmodule Req.StepsTest do
       end)
 
       assert_raise Req.DecompressError,
-                   ~S[decompression failed with format 'zstd', reason: "failed to decompress: ZSTD_CONTENTSIZE_ERROR"],
+                   ~S[zstd decompression failed, reason: "failed to decompress: ZSTD_CONTENTSIZE_ERROR"],
                    fn ->
                      Req.get!(c.url)
                    end

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -601,9 +601,11 @@ defmodule Req.StepsTest do
         |> Plug.Conn.send_resp(200, "bad")
       end)
 
-      assert_raise Req.DecompressError, "decompression failed with format 'zstd'", fn ->
-        Req.get!(c.url)
-      end
+      assert_raise Req.DecompressError,
+                   ~S[decompression failed with format 'zstd', reason: "failed to decompress: ZSTD_CONTENTSIZE_ERROR"],
+                   fn ->
+                     Req.get!(c.url)
+                   end
     end
 
     test "multiple codecs", c do

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -522,27 +522,27 @@ defmodule Req.StepsTest do
   ## Response steps
 
   describe "decompress_body" do
-    test "gzip success", c do
-      Bypass.expect(c.bypass, "GET", "/", fn conn ->
+    test "gzip success" do
+      plug = fn conn ->
         conn
         |> Plug.Conn.put_resp_header("content-encoding", "x-gzip")
         |> Plug.Conn.send_resp(200, :zlib.gzip("foo"))
-      end)
+      end
 
-      resp = Req.get!(c.url)
+      resp = Req.get!(plug: plug)
       assert Req.Response.get_header(resp, "content-encoding") == []
       assert resp.body == "foo"
     end
 
-    test "gzip error", c do
-      Bypass.expect(c.bypass, "GET", "/", fn conn ->
+    test "gzip error" do
+      plug = fn conn ->
         conn
         |> Plug.Conn.put_resp_header("content-encoding", "x-gzip")
         |> Plug.Conn.send_resp(200, "bad")
-      end)
+      end
 
       assert_raise Req.DecompressError, "gzip decompression failed", fn ->
-        Req.get!(c.url)
+        Req.get!(plug: plug)
       end
     end
 
@@ -558,53 +558,53 @@ defmodule Req.StepsTest do
       assert resp.body == "foo"
     end
 
-    test "brotli success", c do
-      Bypass.expect(c.bypass, "GET", "/", fn conn ->
+    test "brotli success" do
+      plug = fn conn ->
         {:ok, body} = :brotli.encode("foo")
 
         conn
         |> Plug.Conn.put_resp_header("content-encoding", "br")
         |> Plug.Conn.send_resp(200, body)
-      end)
+      end
 
-      resp = Req.get!(c.url)
+      resp = Req.get!(plug: plug)
       assert resp.body == "foo"
     end
 
-    test "brotli error", c do
-      Bypass.expect(c.bypass, "GET", "/", fn conn ->
+    test "brotli error" do
+      plug = fn conn ->
         conn
         |> Plug.Conn.put_resp_header("content-encoding", "br")
         |> Plug.Conn.send_resp(200, "bad")
-      end)
+      end
 
       assert_raise Req.DecompressError, "br decompression failed", fn ->
-        Req.get!(c.url)
+        Req.get!(plug: plug)
       end
     end
 
-    test "zstd success", c do
-      Bypass.expect(c.bypass, "GET", "/", fn conn ->
+    test "zstd success" do
+      plug = fn conn ->
         conn
         |> Plug.Conn.put_resp_header("content-encoding", "zstd")
         |> Plug.Conn.send_resp(200, :ezstd.compress("foo"))
-      end)
+      end
 
-      resp = Req.get!(c.url)
+      resp = Req.get!(plug: plug)
       assert resp.body == "foo"
     end
 
-    test "zstd error", c do
-      Bypass.expect(c.bypass, "GET", "/", fn conn ->
+    test "zstd error" do
+      plug = fn conn ->
         conn
         |> Plug.Conn.put_resp_header("content-encoding", "zstd")
         |> Plug.Conn.send_resp(200, "bad")
-      end)
+      end
 
       assert_raise Req.DecompressError,
                    ~S[zstd decompression failed, reason: "failed to decompress: ZSTD_CONTENTSIZE_ERROR"],
                    fn ->
-                     Req.get!(c.url)
+                     Req.get!(plug: plug)
                    end
     end
 


### PR DESCRIPTION
See #335 - Improve decompression failure error handling by returning Req.DecompressError

This PR adds a new error type (below) to handle decompression failures.

```elixir
%Req.DecompressError{
  format: :gzip | :br | :zstd,
  data: binary()
}
```