### PR TITLE
Add more Mox-like functions to Req.Test

### DIFF
--- a/lib/req/test.ex
+++ b/lib/req/test.ex
@@ -168,9 +168,17 @@ defmodule Req.Test do
   @opaque stub() :: atom()
 
   if Code.ensure_loaded?(Plug.Conn) do
-    @type plug() :: {module(), [term()]} | module() | (Plug.Conn.t() -> Plug.Conn.t() | (Plug.Conn.t(), term() -> Plug.Conn.t())
+    @type plug() ::
+            {module(), [term()]}
+            | module()
+            | (Plug.Conn.t() -> Plug.Conn.t())
+            | (Plug.Conn.t(), term() -> Plug.Conn.t())
   else
-    @type plug() :: {module(), [term()]} | module() | (term() -> term() | (term(), term() -> term())
+    @type plug() ::
+            {module(), [term()]}
+            | module()
+            | (term() -> term())
+            | (term(), term() -> term())
   end
 
   @ownership Req.Ownership

--- a/lib/req/test.ex
+++ b/lib/req/test.ex
@@ -168,9 +168,9 @@ defmodule Req.Test do
   @opaque stub() :: atom()
 
   if Code.ensure_loaded?(Plug.Conn) do
-    @type plug() :: {module(), [term()]} | module() | (Plug.Conn.t() -> Plug.Conn.t())
+    @type plug() :: {module(), [term()]} | module() | (Plug.Conn.t() -> Plug.Conn.t() | (Plug.Conn.t(), term() -> Plug.Conn.t())
   else
-    @type plug() :: {module(), [term()]} | module() | (term() -> term())
+    @type plug() :: {module(), [term()]} | module() | (term() -> term() | (term(), term() -> term())
   end
 
   @ownership Req.Ownership

--- a/test/req/test_test.exs
+++ b/test/req/test_test.exs
@@ -2,43 +2,43 @@ defmodule Req.TestTest do
   use ExUnit.Case, async: true
   doctest Req.Test
 
-  test "stub" do
+  test "stub/2 and fetch_stub!/1" do
     assert_raise RuntimeError, ~r/cannot find stub/, fn ->
-      Req.Test.stub(:foo)
+      Req.Test.fetch_stub!(:foo)
     end
 
-    Req.Test.stub(:foo, 1)
-    assert Req.Test.stub(:foo) == 1
+    Req.Test.stub(:foo, {MyPlug, [1]})
+    assert Req.Test.fetch_stub!(:foo) == {MyPlug, [1]}
 
-    Req.Test.stub(:foo, 2)
-    assert Req.Test.stub(:foo) == 2
+    Req.Test.stub(:foo, {MyPlug, [2]})
+    assert Req.Test.fetch_stub!(:foo) == {MyPlug, [2]}
 
     Task.async(fn ->
-      assert Req.Test.stub(:foo) == 2
-      Req.Test.stub(:foo, 3)
+      assert Req.Test.fetch_stub!(:foo) == {MyPlug, [2]}
+      Req.Test.stub(:foo, {MyPlug, [3]})
     end)
     |> Task.await()
 
-    assert Req.Test.stub(:foo) == 2
+    assert Req.Test.fetch_stub!(:foo) == {MyPlug, [2]}
   end
 
   describe "expect/3" do
     test "works in the normal expectation-based way" do
       Req.Test.expect(:foo, 2, 1)
-      assert Req.Test.stub(:foo) == 1
-      assert Req.Test.stub(:foo) == 1
+      assert Req.Test.fetch_stub!(:foo) == 1
+      assert Req.Test.fetch_stub!(:foo) == 1
 
       assert_raise RuntimeError, "no stub or expectations for :foo", fn ->
-        Req.Test.stub(:foo)
+        Req.Test.fetch_stub!(:foo)
       end
     end
 
     test "works with the default expected count of 1" do
       Req.Test.expect(:foo_default, 1)
-      assert Req.Test.stub(:foo_default) == 1
+      assert Req.Test.fetch_stub!(:foo_default) == 1
 
       assert_raise RuntimeError, "no stub or expectations for :foo_default", fn ->
-        assert Req.Test.stub(:foo_default)
+        assert Req.Test.fetch_stub!(:foo_default)
       end
     end
   end
@@ -69,7 +69,7 @@ defmodule Req.TestTest do
       test_pid = self()
       ref = make_ref()
 
-      Req.Test.stub(:foo, 1)
+      Req.Test.stub(:foo, Plug.Logger)
 
       child_pid =
         spawn(fn ->
@@ -77,15 +77,15 @@ defmodule Req.TestTest do
           Process.delete(:"$callers")
 
           receive do
-            :go -> send(test_pid, {ref, Req.Test.stub(:foo)})
+            :go -> send(test_pid, {ref, Req.Test.fetch_stub!(:foo)})
           end
         end)
 
-      Req.Test.stub(:foo, 1)
+      Req.Test.stub(:foo, Plug.Logger)
       Req.Test.allow(:foo, self(), child_pid)
 
       send(child_pid, :go)
-      assert_receive {^ref, 1}
+      assert_receive {^ref, Plug.Logger}
     end
   end
 

--- a/test/req/test_test.exs
+++ b/test/req/test_test.exs
@@ -4,41 +4,41 @@ defmodule Req.TestTest do
 
   test "stub/2 and fetch_stub!/1" do
     assert_raise RuntimeError, ~r/cannot find stub/, fn ->
-      Req.Test.fetch_stub!(:foo)
+      Req.Test.__fetch_stub__(:foo)
     end
 
     Req.Test.stub(:foo, {MyPlug, [1]})
-    assert Req.Test.fetch_stub!(:foo) == {MyPlug, [1]}
+    assert Req.Test.__fetch_stub__(:foo) == {MyPlug, [1]}
 
     Req.Test.stub(:foo, {MyPlug, [2]})
-    assert Req.Test.fetch_stub!(:foo) == {MyPlug, [2]}
+    assert Req.Test.__fetch_stub__(:foo) == {MyPlug, [2]}
 
     Task.async(fn ->
-      assert Req.Test.fetch_stub!(:foo) == {MyPlug, [2]}
+      assert Req.Test.__fetch_stub__(:foo) == {MyPlug, [2]}
       Req.Test.stub(:foo, {MyPlug, [3]})
     end)
     |> Task.await()
 
-    assert Req.Test.fetch_stub!(:foo) == {MyPlug, [2]}
+    assert Req.Test.__fetch_stub__(:foo) == {MyPlug, [2]}
   end
 
   describe "expect/3" do
     test "works in the normal expectation-based way" do
       Req.Test.expect(:foo, 2, 1)
-      assert Req.Test.fetch_stub!(:foo) == 1
-      assert Req.Test.fetch_stub!(:foo) == 1
+      assert Req.Test.__fetch_stub__(:foo) == 1
+      assert Req.Test.__fetch_stub__(:foo) == 1
 
       assert_raise RuntimeError, "no stub or expectations for :foo", fn ->
-        Req.Test.fetch_stub!(:foo)
+        Req.Test.__fetch_stub__(:foo)
       end
     end
 
     test "works with the default expected count of 1" do
       Req.Test.expect(:foo_default, 1)
-      assert Req.Test.fetch_stub!(:foo_default) == 1
+      assert Req.Test.__fetch_stub__(:foo_default) == 1
 
       assert_raise RuntimeError, "no stub or expectations for :foo_default", fn ->
-        assert Req.Test.fetch_stub!(:foo_default)
+        assert Req.Test.__fetch_stub__(:foo_default)
       end
     end
   end
@@ -77,7 +77,7 @@ defmodule Req.TestTest do
           Process.delete(:"$callers")
 
           receive do
-            :go -> send(test_pid, {ref, Req.Test.fetch_stub!(:foo)})
+            :go -> send(test_pid, {ref, Req.Test.__fetch_stub__(:foo)})
           end
         end)
 


### PR DESCRIPTION
@wojtekmach I’m not sure how you'll feel about this but to me this is step number 1 towards what we talked about. To have complete mock functionality, we'll probably need this. It's really low maintenance (Mox has been like this for the past 7-8 years?) and if we sort of vendor its code (modified to fit this) and nimble_ownership's code you'll have top-notch testing support, IMO. Thoughts?