### PR TITLE
fix: Fix the aws signature v4 computation with custom headers

### DIFF
--- a/lib/req/utils.ex
+++ b/lib/req/utils.ex
@@ -48,6 +48,9 @@ defmodule Req.Utils do
           {"x-amz-date", datetime_string}
         ]
 
+    ## canonical_headers needs to be sorted for canonical_request construction
+    canonical_headers = Enum.sort(canonical_headers)
+
     signed_headers =
       Enum.map_intersperse(
         Enum.sort(canonical_headers),


### PR DESCRIPTION
tl;dr - Req library doesn't derive the aws v4 signature properly while using custom headers. 

AWS signature v4 computation requires the `canonical_headers` to be alphabetically sorted - reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#create-canonical-request

Here is a detailed example:

```
defmodule ElixirHelloworldTest do
  use ExUnit.Case
  doctest ElixirHelloworld

  test "greets the world" do
    assert ElixirHelloworld.hello() == :world
    IO.puts(Req.new(
      aws_sigv4: [
        access_key_id: "<>",
        secret_access_key: "<>",
        region: "auto",
        service: :s3
      ],
      url: "https://silent-voice-3347.fly.storage.tigris.dev",
      params: %{
        "list-type" => "2"
      },
      headers: %{
      "X-Tigris-Query" => "`Content-Length` > 6"
      }
    )
    |> Req.run())
  end
end
```

As you can see there is a custom header being passed on here `X-Tigris-Query`. The canonical request formed for this request is 

```
GET
/
list-type=2
accept-encoding:gzip
host:silent-voice-3347.fly.storage.tigris.dev
user-agent:req/0.5.1
x-tigris-query:`Content-Length` > 6
x-amz-content-sha256:<>
x-amz-date:20240625T065255Z

accept-encoding;host;user-agent;x-amz-content-sha256;x-amz-date;x-tigris-query
<>
``` 

Similarly for 

```
defmodule ElixirHelloworldTest do
  use ExUnit.Case
  doctest ElixirHelloworld

  test "greets the world" do
    assert ElixirHelloworld.hello() == :world
    IO.puts(Req.new(
      aws_sigv4: [
        access_key_id: "<>",
        secret_access_key: "<>",
        region: "auto",
        service: :s3
      ],
      url: "https://silent-voice-3347.fly.storage.tigris.dev",
      params: %{
        "list-type" => "2"
      },
      headers: %{
      "X-Tigris-Query" => "`Content-Length` > 6",
      "A" => "test",
      "F" => "test",
      "C" => "test",
      "B" => "test"
      }
    )
    |> Req.run())
  end
end
```

canonical request is

```
GET
/
list-type=2
a:test
accept-encoding:gzip
b:test
c:test
f:test
host:silent-voice-3347.fly.storage.tigris.dev
user-agent:req/0.5.1
x-tigris-query:`Content-Length` > 6
x-amz-content-sha256:<>
x-amz-date:20240625T065427Z

a;accept-encoding;b;c;f;host;user-agent;x-amz-content-sha256;x-amz-date;x-tigris-query
<>
```

`x-tigris-query` doesn't fit in sorted headers. This causes the incorrect signature calculation and gets rejected on server.

P.S. I have never used Elixir language.