### PR TITLE
handle {:shared_owner, owner} in __fetch_plug__

### DIFF
--- a/lib/req/test.ex
+++ b/lib/req/test.ex
@@ -384,6 +384,17 @@ defmodule Req.Test do
             raise "no mock or stub for #{inspect(name)}"
         end
 
+      {:shared_owner, owner} when is_pid(owner) ->
+        result = Req.Test.Ownership.get_owned(@ownership, owner)[name]
+
+        case result do
+          %{stub: value} ->
+            value
+
+          {:ok, {:error, :no_expectations_and_no_stub}} ->
+            raise "no mock or stub for #{inspect(name)}"
+        end
+
       :error ->
         raise "cannot find mock/stub #{inspect(name)} in process #{inspect(self())}"
     end

--- a/test/req/test_test.exs
+++ b/test/req/test_test.exs
@@ -28,6 +28,8 @@ defmodule Req.TestTest do
       assert Req.Test.__fetch_plug__(:bar) == {SharedPlug, [1]}
     end)
     |> Task.await()
+  after
+    Req.Test.set_req_test_to_private()
   end
 
   describe "expect/3" do

--- a/test/req/test_test.exs
+++ b/test/req/test_test.exs
@@ -20,6 +20,14 @@ defmodule Req.TestTest do
     |> Task.await()
 
     assert Req.Test.__fetch_plug__(:foo) == {MyPlug, [2]}
+
+    Req.Test.stub(:bar, {SharedPlug, [1]})
+    Req.Test.set_req_test_to_shared()
+
+    Task.async(fn ->
+      assert Req.Test.__fetch_plug__(:bar) == {SharedPlug, [1]}
+    end)
+    |> Task.await()
   end
 
   describe "expect/3" do


### PR DESCRIPTION
When putting Req.Test into shared mode, I was getting a CaseClauseError when trying to access plugs.

```elixir
** (CaseClauseError) no case clause matching: {:shared_owner, #PID<0.681.0>}
    (req 0.5.1) lib/req/test.ex:365: Req.Test.__fetch_plug__/1
    (req 0.5.1) lib/req/test.ex:621: Req.Test.call/2
    (req 0.5.1) lib/req/steps.ex:1268: Req.Steps.run_plug/1
    (req 0.5.1) lib/req/request.ex:1101: Req.Request.run_request/1
    (req 0.5.1) lib/req/request.ex:1045: Req.Request.run/1
```

This PR adds a new case that handles the {:shared_owner, owner} tuple returned by Req.Test.Ownership.fetch_owner/4 when in shared mode.