### PR TITLE
use `:finch` value to override finch instance

### DIFF
--- a/lib/req/finch.ex
+++ b/lib/req/finch.ex
@@ -309,8 +309,12 @@ defmodule Req.Finch do
       Map.has_key?(request.options, :connect_options) or Map.has_key?(request.options, :inet6)
 
     cond do
-      request.options[:finch] && custom_options? ->
-        raise ArgumentError, "cannot set both :finch and :connect_options"
+      name = request.options[:finch] ->
+        if custom_options? do
+          raise ArgumentError, "cannot set both :finch and :connect_options"
+        else
+          name
+        end
 
       custom_options? ->
         pool_options = pool_options(request.options)

--- a/test/req/finch_test.exs
+++ b/test/req/finch_test.exs
@@ -183,6 +183,12 @@ defmodule Req.FinchTest do
       end
     end
 
+    test ":finch option" do
+      assert_raise ArgumentError, "unknown registry: MyFinch", fn ->
+        Req.get!("http://localhost", finch: MyFinch)
+      end
+    end
+
     test ":finch and :connect_options" do
       assert_raise ArgumentError, "cannot set both :finch and :connect_options", fn ->
         Req.request!(finch: MyFinch, connect_options: [timeout: 0])


### PR DESCRIPTION
Hi, 
I was unable to override the finch instance and traced it back to commit https://github.com/wojtekmach/req/commit/7ee7fd8effe22fd59d87723c86ba652d4a0c6a0e which removed the functionality.

This PR should revert that + adds a test to check that the `:finch` option can be used.