### PR TITLE
fix: encode path in url for aws_sigv4_url/1

### DIFF
--- a/lib/req/utils.ex
+++ b/lib/req/utils.ex
@@ -201,7 +201,7 @@ defmodule Req.Utils do
         secret_access_key
       )
 
-    put_in(url.query, canonical_query_string <> "&X-Amz-Signature=#{signature}")
+    %{url | path: path, query: canonical_query_string <> "&X-Amz-Signature=#{signature}"}
   end
 
   defp canonical_host_header(headers, %URI{} = url) do

--- a/test/req/utils_test.exs
+++ b/test/req/utils_test.exs
@@ -100,7 +100,7 @@ defmodule Req.UtilsTest do
 
       url2 =
         """
-        https://s3/foo/:bar?\
+        https://s3/foo/%3Abar?\
         X-Amz-Algorithm=AWS4-HMAC-SHA256\
         &X-Amz-Credential=dummy-access-key-id%2F20240101%2Fdummy-region%2Fs3%2Faws4_request\
         &X-Amz-Date=20240101T090000Z\
@@ -127,7 +127,7 @@ defmodule Req.UtilsTest do
 
       url2 =
         """
-        https://s3-compatible.com:4433/foo/:bar?\
+        https://s3-compatible.com:4433/foo/%3Abar?\
         X-Amz-Algorithm=AWS4-HMAC-SHA256\
         &X-Amz-Credential=dummy-access-key-id%2F20240101%2Fdummy-region%2Fs3%2Faws4_request\
         &X-Amz-Date=20240101T090000Z\


### PR DESCRIPTION
I encountered a `SignatureDoesNotMatch` when the object key contains characters that need to be escaped, such as spaces or CJK characters.

The `path` has been encoded at 168L, so we just update the `url` before returning.
https://github.com/wojtekmach/req/blob/a3c48b845119069909e9197cd53264782513b4b4/lib/req/utils.ex#L168