### PR TITLE
Ignore :into collectable for non-200 responses

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -285,6 +285,9 @@ defmodule Req do
 
                into: File.stream!("path")
 
+          Note that the collectable is only used, if the response status is 200. In other cases,
+          the body is accumulated and processed as usual.
+
         * `:self` - stream response body into the current process mailbox.
 
           Received messages should be parsed with `Req.parse_message/2`.

--- a/lib/req/request.ex
+++ b/lib/req/request.ex
@@ -92,6 +92,9 @@ defmodule Req.Request do
 
               into: File.stream!("path")
 
+          Note that the collectable is only used, if the response status is 200. In other cases,
+          the body is accumulated and processed as usual.
+
     * `:options` - the options to be used by steps. The exact representation of options is private.
       Calling `request.options[key]`, `put_in(request.options[key], value)`, and
       `update_in(request.options[key], fun)` is allowed. `get_option/3` and `delete_option/2`

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1032,17 +1032,20 @@ defmodule Req.Steps do
           end
 
         collectable ->
-          {acc, collector} = Collectable.into(collectable)
-
           response =
             Req.Response.new(
               status: conn.status,
               headers: conn.resp_headers
             )
 
-          acc = collector.(acc, {:cont, conn.resp_body})
-          acc = collector.(acc, :done)
-          {request, %{response | body: acc}}
+          if conn.status == 200 do
+            {acc, collector} = Collectable.into(collectable)
+            acc = collector.(acc, {:cont, conn.resp_body})
+            acc = collector.(acc, :done)
+            {request, %{response | body: acc}}
+          else
+            {request, %{response | body: conn.resp_body}}
+          end
       end
     end
 

--- a/test/req/finch_test.exs
+++ b/test/req/finch_test.exs
@@ -346,28 +346,22 @@ defmodule Req.FinchTest do
       assert resp.body == ["chunk1", "chunk2"]
     end
 
-    @tag :tmp_dir
-    test "into: collectable non-200", %{tmp_dir: tmp_dir} do
+    test "into: collectable non-200" do
       # Ignores the collectable and returns body as usual
-
-      File.mkdir_p!(tmp_dir)
-      file = Path.join(tmp_dir, "result.bin")
 
       %{url: url} =
         start_http_server(fn conn ->
-          Req.Test.json(%{conn | status: 404}, %{error: :not_found})
+          Req.Test.json(%{conn | status: 404}, %{error: "not found"})
         end)
 
       resp =
         Req.get!(
           url: url,
-          into: File.stream!(file)
+          into: :not_a_collectable
         )
 
       assert resp.status == 404
       assert resp.body == %{"error" => "not found"}
-
-      refute File.exists?(file)
     end
 
     test "into: collectable handle error" do

--- a/test/req/finch_test.exs
+++ b/test/req/finch_test.exs
@@ -354,20 +354,8 @@ defmodule Req.FinchTest do
       file = Path.join(tmp_dir, "result.bin")
 
       %{url: url} =
-        start_tcp_server(fn socket ->
-          {:ok, "GET / HTTP/1.1\r\n" <> _} = :gen_tcp.recv(socket, 0)
-
-          body = ~s|{"error": "not found"}|
-
-          data = """
-          HTTP/1.1 404 OK
-          content-length: #{byte_size(body)}
-          content-type: application/json
-
-          #{body}
-          """
-
-          :ok = :gen_tcp.send(socket, data)
+        start_http_server(fn conn ->
+          Req.Test.json(%{conn | status: 404}, %{error: :not_found})
         end)
 
       resp =

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -1942,7 +1942,7 @@ defmodule Req.StepsTest do
             {:ok, conn} = Plug.Conn.chunk(conn, "bar")
             conn
           end,
-          into: []
+          into: File.stream!(file)
         )
 
       resp = Req.request!(req)

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -1927,12 +1927,8 @@ defmodule Req.StepsTest do
       refute_receive _
     end
 
-    @tag :tmp_dir
-    test "into: collectable non-200", %{tmp_dir: tmp_dir} do
+    test "into: collectable non-200" do
       # Ignores the collectable and returns body as usual
-
-      File.mkdir_p!(tmp_dir)
-      file = Path.join(tmp_dir, "result.bin")
 
       req =
         Req.new(
@@ -1942,15 +1938,13 @@ defmodule Req.StepsTest do
             {:ok, conn} = Plug.Conn.chunk(conn, "bar")
             conn
           end,
-          into: File.stream!(file)
+          into: :not_a_collectable
         )
 
       resp = Req.request!(req)
       assert resp.status == 404
       assert resp.body == "foobar"
       refute_receive _
-
-      refute File.exists?(file)
     end
 
     test "errors" do


### PR DESCRIPTION
Currently when we pass `into: collectable`, the body is streamed into the collectable, regardless the status. This can be problematics for collectables with side effects. For example, I imagine a common use case may be `into: File.stream!(path)` to download a file, and in case of an error, we would save error message body instead.

There is one concern, that I'm not sure how to solve, hence a draft (details in separate comment).