### PR TITLE
Add option to configure Finch pool :pool_max_idle_time

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -403,6 +403,9 @@ defmodule Req do
 
     * `:unix_socket` - if set, connect through the given UNIX domain socket.
 
+    * `:pool_max_idle_time` - the maximum number of milliseconds that a pool can be
+      idle before being terminated, used only by HTTP1 pools. Default to `:infinity`.
+
     * `:finch_private` - a map or keyword list of private metadata to add to the Finch request. May be useful
       for adding custom data when handling telemetry with `Finch.Telemetry`.
 

--- a/lib/req/finch.ex
+++ b/lib/req/finch.ex
@@ -365,6 +365,7 @@ defmodule Req.Finch do
   def pool_options(options) when is_map(options) do
     connect_options = options[:connect_options] || []
     inet6_options = options |> Map.take([:inet6]) |> Enum.to_list()
+    pool_options = options |> Map.take([:pool_max_idle_time]) |> Enum.to_list()
 
     Req.Request.validate_options(
       connect_options,
@@ -413,7 +414,8 @@ defmodule Req.Finch do
           [:http1]
       end
 
-    [protocols: protocols] ++
+    pool_options ++
+      [protocols: protocols] ++
       if conn_opts != [] do
         [conn_opts: conn_opts]
       else

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -59,6 +59,7 @@ defmodule Req.Steps do
       :receive_timeout,
       :pool_timeout,
       :unix_socket,
+      :pool_max_idle_time,
 
       # TODO: Remove on Req 1.0
       :output,
@@ -749,6 +750,9 @@ defmodule Req.Steps do
     * `:receive_timeout` - socket receive timeout in milliseconds, defaults to `15_000`.
 
     * `:unix_socket` - if set, connect through the given UNIX domain socket.
+
+    * `:pool_max_idle_time` - the maximum number of milliseconds that a pool can be
+      idle before being terminated, used only by HTTP1 pools. Default to `:infinity`.
 
     * `:finch_private` - a map or keyword list of private metadata to add to the Finch request.
       May be useful for adding custom data when handling telemetry with `Finch.Telemetry`.


### PR DESCRIPTION
In some cases, a long-running app may want to make requests to arbitrary URLs (e.g. specified by the user). By default finch would start a separate pool for each host and keep it indefinitely, but this can be configured with the `:pool_max_idle_time` option.

Initially I wanted to just use a custom finch pool and do `Req.new(finch: TransientFinchPool)`, however we also use `:connect_options`, and these cannot be used together. Hence, I'm proposing to add the Finch pool option. Thoughts?