### PR TITLE
Clarify that raw disables both decompression and decoding

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1390,7 +1390,7 @@ defmodule Req.Steps do
 
   ## Options
 
-    * `:raw` - if set to `true`, disables response body decompression. Defaults to `false`.
+    * `:raw` - if set to `true`, disables response body decompression & decoding. Defaults to `false`.
 
   ## Examples
 
@@ -1582,7 +1582,7 @@ defmodule Req.Steps do
 
     * `:decode_json` - options to pass to `Jason.decode/2`, defaults to `[]`.
 
-    * `:raw` - if set to `true`, disables response body decoding. Defaults to `false`.
+    * `:raw` - if set to `true`, disables response body decoding & decompression. Defaults to `false`.
 
   ## Examples
 


### PR DESCRIPTION
Reading the docs for decoding I was confused like "Wait, what is the difference between `:raw` and `:decode_body` then?" And well that is it, searching for `:raw` more unveils it but I think since the option affects both steps mentioning both effects may be worth it :)

Thanks for your excellent work on req! :green_heart: 