### PR TITLE
[DRAFT] use Elixir.JSON rather than Jason for elixir 18.0+

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -264,7 +264,7 @@ defmodule Req do
     * `:decode_body` - if set to `false`, disables automatic response body decoding.
       Defaults to `true`.
 
-    * `:decode_json` - options to pass to `Jason.decode!/2`, defaults to `[]`.
+    * `:decode_json` - options to pass to `JSON.decode!/2`, defaults to `[]`.
 
     * `:into` - where to send the response body. It can be one of:
 

--- a/lib/req/response.ex
+++ b/lib/req/response.ex
@@ -32,6 +32,13 @@ defmodule Req.Response do
             trailers: %{},
             private: %{}
 
+  # TODO: Remove when we require Elixir 1.18
+  @json (if Version.match?(System.version(), "~> 1.18") do
+    JSON
+  else
+    Jason
+  end)
+
   @doc """
   Returns a new response.
 
@@ -118,7 +125,7 @@ defmodule Req.Response do
           response
       end
 
-    Map.replace!(response, :body, Jason.encode!(body))
+    Map.replace!(response, :body, @json.encode!(body))
   end
 
   @doc """

--- a/lib/req/test.ex
+++ b/lib/req/test.ex
@@ -183,6 +183,13 @@ defmodule Req.Test do
 
   @ownership Req.Test.Ownership
 
+  # TODO: Remove when we require Elixir 1.18
+  @json (if Version.match?(System.version(), "~> 1.18") do
+    JSON
+  else
+    Jason
+  end)
+
   @doc """
   Sends JSON response.
 
@@ -202,7 +209,7 @@ defmodule Req.Test do
   if Code.ensure_loaded?(Plug.Test) do
     @spec json(Plug.Conn.t(), term()) :: Plug.Conn.t()
     def json(%Plug.Conn{} = conn, data) do
-      send_resp(conn, conn.status || 200, "application/json", Jason.encode_to_iodata!(data))
+      send_resp(conn, conn.status || 200, "application/json", @json.encode_to_iodata!(data))
     end
 
     defp send_resp(conn, default_status, default_content_type, body) do


### PR DESCRIPTION
This PR isn't quite complete as 1 test is still failing

```
  1) test compress_body request (Req.StepsTest)
     test/req/steps_test.exs:327
     ** (FunctionClauseError) no function clause matching in JSON.decode!/1

     The following arguments were given to JSON.decode!/1:

         # 1
         [~c"{", [[34, "a", 34], 58 | "1"], [], ~c"}"]

     Attempted function clauses (showing 1 out of 1):

         def decode!(binary) when is_binary(binary)

     code: assert @json.decode!(req.body) == %{"a" => 1}
     stacktrace:
       (elixir 1.18.1) lib/json.ex:307: JSON.decode!/1
       test/req/steps_test.exs:329: (test)
```

I will take another look at this tomorrow but id be keen to hear some opinions on this. I assume it's because the elixir JSON module doesn't support converting charlists (where Jason previously has). Hoping this won't be a major blocker...  🤞

Also this is my first PR of this kind, so hopefully I've done a decent job! Please tell me off for any naughty's!!