### PR TITLE
Support custom headers in aws_sigv4_url/1

### DIFF
--- a/lib/req/utils.ex
+++ b/lib/req/utils.ex
@@ -156,13 +156,18 @@ defmodule Req.Utils do
     signed_headers = Enum.map_join(canonical_headers, ";", &elem(&1, 0))
 
     canonical_query_string =
-      URI.encode_query([
-        {"X-Amz-Algorithm", "AWS4-HMAC-SHA256"},
-        {"X-Amz-Credential", "#{access_key_id}/#{date_string}/#{region}/#{service}/aws4_request"},
-        {"X-Amz-Date", datetime_string},
-        {"X-Amz-Expires", expires},
-        {"X-Amz-SignedHeaders", signed_headers}
-      ])
+      URI.encode_query(
+        [
+          {"X-Amz-Algorithm", "AWS4-HMAC-SHA256"},
+          {"X-Amz-Credential",
+           "#{access_key_id}/#{date_string}/#{region}/#{service}/aws4_request"},
+          {"X-Amz-Date", datetime_string},
+          {"X-Amz-Expires", expires},
+          {"X-Amz-SignedHeaders", signed_headers}
+        ],
+        # Ensure spaces are encoded as %20 not +
+        :rfc3986
+      )
 
     path = URI.encode(url.path || "/", &(&1 == ?/ or URI.char_unreserved?(&1)))
 

--- a/test/req/utils_test.exs
+++ b/test/req/utils_test.exs
@@ -138,6 +138,34 @@ defmodule Req.UtilsTest do
 
       assert url1 == url2
     end
+
+    test "custom headers" do
+      options = [
+        access_key_id: "dummy-access-key-id",
+        secret_access_key: "dummy-secret-access-key",
+        region: "dummy-region",
+        service: "s3",
+        datetime: ~U[2024-01-01 09:00:00Z],
+        method: :put,
+        url: "https://s3/foo/hello_world.txt",
+        headers: [{"content-length", 11}]
+      ]
+
+      url1 = to_string(Req.Utils.aws_sigv4_url(options))
+
+      url2 =
+        """
+        https://s3/foo/hello_world.txt?\
+        X-Amz-Algorithm=AWS4-HMAC-SHA256\
+        &X-Amz-Credential=dummy-access-key-id%2F20240101%2Fdummy-region%2Fs3%2Faws4_request\
+        &X-Amz-Date=20240101T090000Z\
+        &X-Amz-Expires=86400\
+        &X-Amz-SignedHeaders=content-length%3Bhost\
+        &X-Amz-Signature=dbb4ae08836db5089a924f2eb52eb52dbc1c372a384a6a99ceb469b14b83e995\
+        """
+
+      assert url1 == url2
+    end
   end
 
   describe "encode_form_multipart" do


### PR DESCRIPTION
S3-compatible APIs support additional headers for certain behaviors. For example, my team wants to create presigned urls for uploading files from the client. To ensure integrity of uploads and keep track of storage consumption by our end users, we want to enforce the uploaded file is the size reported by the client. This can be accomplished using the `content-length` header.

S3 supports `content-length-range` which I see is used by req_s3 `presign_form/1`. However, we're using Cloudflare R2 via their S3-compatible API and it appears that value is not supported but the `content-length` header is. Additionally, we want the exact size to be enforced, not a range or max.

This PR supports arbitrary headers passed to `Req.Utils.aws_sigv4_url/1`. I wasn't entirely sure where this belongs as there is S3-signing-related logic in a few places (this module and req_s3). From what I could tell, signature logic should be added here. Happy to adjust if needed.