### PR TITLE
Support custom query params in Req.Utils.aws_sigv4_url/1

### DIFF
--- a/lib/req/utils.ex
+++ b/lib/req/utils.ex
@@ -266,6 +266,7 @@ defmodule Req.Utils do
     |> Enum.map_join("&", fn {name, value} -> "#{name}=#{value}" end)
   end
 
+  # Spaces must be encoded as %20, not as "+".
   defp format_canonical_query_param({name, value}) do
     name =
       name

--- a/lib/req/utils.ex
+++ b/lib/req/utils.ex
@@ -140,6 +140,7 @@ defmodule Req.Utils do
     {url, options} = Keyword.pop!(options, :url)
     {expires, options} = Keyword.pop(options, :expires, 86400)
     {headers, options} = Keyword.pop(options, :headers, [])
+    {query, options} = Keyword.pop(options, :query, [])
     [] = options
 
     datetime = DateTime.truncate(datetime, :second)
@@ -156,7 +157,7 @@ defmodule Req.Utils do
     signed_headers = Enum.map_join(canonical_headers, ";", &elem(&1, 0))
 
     canonical_query_string =
-      URI.encode_query(
+      format_canonical_query_params(
         [
           {"X-Amz-Algorithm", "AWS4-HMAC-SHA256"},
           {"X-Amz-Credential",
@@ -164,9 +165,7 @@ defmodule Req.Utils do
           {"X-Amz-Date", datetime_string},
           {"X-Amz-Expires", expires},
           {"X-Amz-SignedHeaders", signed_headers}
-        ],
-        # Ensure spaces are encoded as %20 not +
-        :rfc3986
+        ] ++ query
       )
 
     path = URI.encode(url.path || "/", &(&1 == ?/ or URI.char_unreserved?(&1)))
@@ -233,6 +232,8 @@ defmodule Req.Utils do
   end
 
   # Headers must be sorted alphabetically by name
+  # Header names must be lower case
+  # Header values must be trimmed
   # See https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
   defp format_canonical_headers(headers) do
     headers
@@ -240,9 +241,6 @@ defmodule Req.Utils do
     |> Enum.sort(fn {name_1, _}, {name_2, _} -> name_1 < name_2 end)
   end
 
-  # Header names must be lower case
-  # Header values must be trimmed
-  # See https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
   defp format_canonical_header({name, value}) do
     name =
       name
@@ -256,6 +254,34 @@ defmodule Req.Utils do
 
     {name, value}
   end
+
+  # Query params must be sorted alphabetically by name
+  # Query param name and values must be URI-encoded individually
+  # Query params must be sorted after encoding
+  # See https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
+  defp format_canonical_query_params(query_params) do
+    query_params
+    |> Enum.map(&format_canonical_query_param/1)
+    |> Enum.sort(&canonical_query_param_sorter/2)
+    |> Enum.map_join("&", fn {name, value} -> "#{name}=#{value}" end)
+  end
+
+  defp format_canonical_query_param({name, value}) do
+    name =
+      name
+      |> to_string()
+      |> URI.encode(&URI.char_unreserved?/1)
+
+    value =
+      value
+      |> to_string()
+      |> URI.encode(&URI.char_unreserved?/1)
+
+    {name, value}
+  end
+
+  defp canonical_query_param_sorter({name, value_1}, {name, value_2}), do: value_1 < value_2
+  defp canonical_query_param_sorter({name_1, _}, {name_2, _}), do: name_1 < name_2
 
   def aws_sigv4(
         string_to_sign,

--- a/test/req/utils_test.exs
+++ b/test/req/utils_test.exs
@@ -166,6 +166,35 @@ defmodule Req.UtilsTest do
 
       assert url1 == url2
     end
+
+    test "custom query" do
+      options = [
+        access_key_id: "dummy-access-key-id",
+        secret_access_key: "dummy-secret-access-key",
+        region: "dummy-region",
+        service: "s3",
+        datetime: ~U[2024-01-01 09:00:00Z],
+        method: :get,
+        url: "https://s3/foo/hello_world.txt",
+        query: [{"response-content-disposition", ~s(attachment; filename="hello_world.txt")}]
+      ]
+
+      url1 = to_string(Req.Utils.aws_sigv4_url(options))
+
+      url2 =
+        """
+        https://s3/foo/hello_world.txt?\
+        X-Amz-Algorithm=AWS4-HMAC-SHA256\
+        &X-Amz-Credential=dummy-access-key-id%2F20240101%2Fdummy-region%2Fs3%2Faws4_request\
+        &X-Amz-Date=20240101T090000Z\
+        &X-Amz-Expires=86400\
+        &X-Amz-SignedHeaders=host\
+        &response-content-disposition=attachment%3B%20filename%3D%22hello_world.txt%22\
+        &X-Amz-Signature=574a638441ff0e623c800b7379408748d58f3e6679e3ca2619c5900fa030beed\
+        """
+
+      assert url1 == url2
+    end
   end
 
   describe "encode_form_multipart" do


### PR DESCRIPTION
Similar to https://github.com/wojtekmach/req/pull/443, S3-compatible APIs support additional query parameters for certain behaviors. One example is to set the response content disposition for file downloads, as motivated by https://github.com/wojtekmach/req_s3/issues/8.

This PR supports arbitrary query parameters passed to `Req.Utils.aws_sigv4_url/1`.