### PR TITLE
Do not carry `halt` status between retries

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -2167,7 +2167,7 @@ defmodule Req.Steps do
       log_retry(response_or_exception, retry_count, max_retries, delay, log_level)
       Process.sleep(delay)
       request = Req.Request.put_private(request, :req_retry_count, retry_count + 1)
-      {request, response_or_exception} = Req.Request.run_request(request)
+      {request, response_or_exception} = Req.Request.run_request(%{request | halted: false})
       Req.Request.halt(request, response_or_exception)
     else
       {request, response_or_exception}

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -1713,6 +1713,37 @@ defmodule Req.StepsTest do
       assert_received :ping
       refute_received _
     end
+
+    @tag :capture_log
+    test "does not carry `halted` status over", c do
+      adapter = fn request ->
+        request = Req.Request.update_private(request, :attempt, 0, &(&1 + 1))
+
+        attempt = request.private.attempt
+
+        if attempt < 2 do
+          Req.Request.halt(request, Req.Response.new(status: 500, body: "oops"))
+        else
+          {request, Req.Response.new(status: 200, body: "ok")}
+        end
+      end
+
+      response_step = fn
+        {request, %Req.Response{} = response} ->
+          response = Req.Response.put_private(response, :ran_response_step, true)
+          {request, response}
+
+        {request, response} ->
+          {request, response}
+      end
+
+      response =
+        Req.new(url: c.url, adapter: adapter, retry_delay: &Integer.pow(2, &1))
+        |> Req.Request.append_response_steps(response_step: response_step)
+        |> Req.request!()
+
+      assert %{ran_response_step: true} = response.private
+    end
   end
 
   @tag :tmp_dir


### PR DESCRIPTION
When retrying a request that halted, but the halt reason is retriable, the `halted: true` shouldn't carry over to the next retry.

Fixes https://github.com/wojtekmach/req/issues/342