### PR TITLE
`:query_params` option for `aws_sigv4_url/1`

### DIFF
--- a/lib/req/utils.ex
+++ b/lib/req/utils.ex
@@ -140,6 +140,7 @@ defmodule Req.Utils do
     {url, options} = Keyword.pop!(options, :url)
     {expires, options} = Keyword.pop(options, :expires, 86400)
     {headers, options} = Keyword.pop(options, :headers, [])
+    {query_params, options} = Keyword.pop(options, :query_params, %{})
     [] = options
 
     datetime = DateTime.truncate(datetime, :second)
@@ -164,7 +165,7 @@ defmodule Req.Utils do
           {"X-Amz-Date", datetime_string},
           {"X-Amz-Expires", expires},
           {"X-Amz-SignedHeaders", signed_headers}
-        ],
+        ] ++ Map.to_list(query_params),
         # Ensure spaces are encoded as %20 not +
         :rfc3986
       )

--- a/lib/req/utils.ex
+++ b/lib/req/utils.ex
@@ -165,7 +165,7 @@ defmodule Req.Utils do
           {"X-Amz-Date", datetime_string},
           {"X-Amz-Expires", expires},
           {"X-Amz-SignedHeaders", signed_headers}
-        ] ++ Map.to_list(query_params),
+        ] ++ Enum.to_list(query_params),
         # Ensure spaces are encoded as %20 not +
         :rfc3986
       )

--- a/test/req/utils_test.exs
+++ b/test/req/utils_test.exs
@@ -166,6 +166,35 @@ defmodule Req.UtilsTest do
 
       assert url1 == url2
     end
+
+    test "query params" do
+      options = [
+        access_key_id: "dummy-access-key-id",
+        secret_access_key: "dummy-secret-access-key",
+        region: "dummy-region",
+        service: "s3",
+        datetime: ~U[2024-01-01 09:00:00Z],
+        method: :get,
+        query_params: %{"response-content-disposition" => "attachment; filename=\"cat.webp\""},
+        url: "https://s3/foo/:bar"
+      ]
+
+      url1 = to_string(Req.Utils.aws_sigv4_url(options))
+
+      url2 =
+        """
+        https://s3/foo/%3Abar?\
+        X-Amz-Algorithm=AWS4-HMAC-SHA256\
+        &X-Amz-Credential=dummy-access-key-id%2F20240101%2Fdummy-region%2Fs3%2Faws4_request\
+        &X-Amz-Date=20240101T090000Z\
+        &X-Amz-Expires=86400\
+        &X-Amz-SignedHeaders=host\
+        &response-content-disposition=attachment%3B%20filename%3D%22cat.webp%22\
+        &X-Amz-Signature=43c08800205ad36d7afec01c08b223b67f710bb41d58ccba0eb1380caa6ee99c\
+        """
+
+      assert url1 == url2
+    end
   end
 
   describe "encode_form_multipart" do


### PR DESCRIPTION
This adds support for adding query params to presigned URLs. S3 allows response headers to be overridden using query params such as `response-cache-control`, `response-content-disposition`, `response-content-encoding`, etc. See https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html for details.

I've tested this implementation by making requests to S3 with `response-content-disposition` and `response-cache-control`.

If this gets merged then I'll submit a separate pull-request to add support for this to `ReqS3.presign_url/1`.

Thanks!