### PR TITLE
Support any enumerable in mutlipart 2

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -398,7 +398,9 @@ defmodule Req.Steps do
 
         * `File.Stream`
 
-        * `{value, options}` tuple. Supported options are `:filename` and `:content_type`
+        * `Enumerable` (optionally takes `:size`, which is used for content-length header calculation)
+
+        * `{value, options}` tuple. Supported options are: `:filename`, `:content_type`, `:size`
 
     * `:json` - if set, encodes the request body as JSON (using `Jason.encode_to_iodata!/1`), sets
       the `accept` header to `application/json`, and the `content-type` header to `application/json`.
@@ -418,6 +420,14 @@ defmodule Req.Steps do
       %{"a" => "1"}
       iex> resp.body["files"]
       %{"b" => "2"}
+
+  Encoding streaming form (`multipart/form-data`):
+
+      iex> stream = Stream.cycle(["abc"]) |> Stream.take(3)
+      iex> fields = [file: {stream, filename: "b.txt", size: 9}]
+      iex> resp = Req.post!("https://httpbin.org/anything", form_multipart: fields)
+      iex> resp.body["files"]
+      %{"file" => "abcabcabc"}
 
   Encoding JSON:
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -436,7 +436,7 @@ defmodule Req.Steps do
 
         %{request | body: multipart.body}
         |> Req.Request.put_new_header("content-type", multipart.content_type)
-        |> Req.Request.put_new_header("content-length", Integer.to_string(multipart.size))
+        |> then(&maybe_put_content_length(&1, multipart.size))
 
       data = request.options[:json] ->
         %{request | body: Jason.encode_to_iodata!(data)}
@@ -446,6 +446,12 @@ defmodule Req.Steps do
       true ->
         request
     end
+  end
+
+  defp maybe_put_content_length(req, nil), do: req
+
+  defp maybe_put_content_length(req, size) do
+    Req.Request.put_new_header(req, "content-length", Integer.to_string(size))
   end
 
   @doc """

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -398,9 +398,19 @@ defmodule Req.Steps do
 
         * `File.Stream`
 
-        * `Enumerable` (optionally takes `:size`, which is used for content-length header calculation)
+        * `Enumerable`
 
-        * `{value, options}` tuple. Supported options are: `:filename`, `:content_type`, `:size`
+        * `{value, options}` tuple.
+        
+           `value` can be any of the values mentioned above.
+           
+           Supported options are: `:filename`, `:content_type`, and `:size`.
+           
+           When `value` is an `Enumerable`, option `:size` can be set with
+           the binary size of the `value`. The size will be used to calculate
+           and send the `content-length` header which might be required for
+           some servers. There is no need to pass `:size` for `integer`,
+           `iodata`, and `File.Stream` values as it's automatically calculated.
 
     * `:json` - if set, encodes the request body as JSON (using `Jason.encode_to_iodata!/1`), sets
       the `accept` header to `application/json`, and the `content-type` header to `application/json`.
@@ -423,6 +433,13 @@ defmodule Req.Steps do
 
   Encoding streaming form (`multipart/form-data`):
 
+      iex> stream = Stream.cycle(["abc"]) |> Stream.take(3)
+      iex> fields = [file: {stream, filename: "b.txt"}]
+      iex> resp = Req.post!("https://httpbin.org/anything", form_multipart: fields)
+      iex> resp.body["files"]
+      %{"file" => "abcabcabc"}
+
+      # with explicit :size
       iex> stream = Stream.cycle(["abc"]) |> Stream.take(3)
       iex> fields = [file: {stream, filename: "b.txt", size: 9}]
       iex> resp = Req.post!("https://httpbin.org/anything", form_multipart: fields)

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -401,11 +401,11 @@ defmodule Req.Steps do
         * `Enumerable`
 
         * `{value, options}` tuple.
-        
+
            `value` can be any of the values mentioned above.
-           
+
            Supported options are: `:filename`, `:content_type`, and `:size`.
-           
+
            When `value` is an `Enumerable`, option `:size` can be set with
            the binary size of the `value`. The size will be used to calculate
            and send the `content-length` header which might be required for

--- a/lib/req/utils.ex
+++ b/lib/req/utils.ex
@@ -493,17 +493,23 @@ defmodule Req.Utils do
     }
   end
 
+  defp add_sizes(size1, size2) when is_nil(size1) or is_nil(size2), do: nil
+  defp add_sizes(size1, size2) when is_number(size1) and is_number(size2), do: size1 + size2
+
+  defp add_sizes(_size1, _size2),
+    do: raise(ArgumentError, "multipart part sizes must be integers or nil")
+
   defp add_form_parts({parts1, size1}, {parts2, size2})
        when is_list(parts1) and is_list(parts2) do
-    {[parts1, parts2], size1 + size2}
+    {[parts1, parts2], add_sizes(size1, size2)}
   end
 
   defp add_form_parts({parts1, size1}, {parts2, size2}) do
-    {Stream.concat(parts1, parts2), size1 + size2}
+    {Stream.concat(parts1, parts2), add_sizes(size1, size2)}
   end
 
   defp encode_form_part({name, {value, options}}, boundary) do
-    options = Keyword.validate!(options, [:filename, :content_type])
+    options = Keyword.validate!(options, [:filename, :content_type, :size])
 
     {parts, parts_size, options} =
       case value do
@@ -533,6 +539,12 @@ defmodule Req.Utils do
             end)
 
           {stream, size, options}
+
+        enum ->
+          Enumerable.impl_for!(enum)
+          size = Keyword.get(options, :size)
+
+          {enum, size, options}
       end
 
     params =

--- a/lib/req/utils.ex
+++ b/lib/req/utils.ex
@@ -493,11 +493,8 @@ defmodule Req.Utils do
     }
   end
 
-  defp add_sizes(size1, size2) when is_nil(size1) or is_nil(size2), do: nil
-  defp add_sizes(size1, size2) when is_number(size1) and is_number(size2), do: size1 + size2
-
-  defp add_sizes(_size1, _size2),
-    do: raise(ArgumentError, "multipart part sizes must be integers or nil")
+  defp add_sizes(nil, nil), do: nil
+  defp add_sizes(size1, size2), do: size1 + size2
 
   defp add_form_parts({parts1, size1}, {parts2, size2})
        when is_list(parts1) and is_list(parts2) do
@@ -541,7 +538,6 @@ defmodule Req.Utils do
           {stream, size, options}
 
         enum ->
-          Enumerable.impl_for!(enum)
           size = Keyword.get(options, :size)
 
           {enum, size, options}

--- a/lib/req/utils.ex
+++ b/lib/req/utils.ex
@@ -493,7 +493,8 @@ defmodule Req.Utils do
     }
   end
 
-  defp add_sizes(nil, nil), do: nil
+  defp add_sizes(_, nil), do: nil
+  defp add_sizes(nil, _), do: nil
   defp add_sizes(size1, size2), do: size1 + size2
 
   defp add_form_parts({parts1, size1}, {parts2, size2})

--- a/test/req/utils_test.exs
+++ b/test/req/utils_test.exs
@@ -203,6 +203,72 @@ defmodule Req.UtilsTest do
              """
     end
 
+    test "it works with size" do
+      %{content_type: content_type, body: body, size: size} =
+        Req.Utils.encode_form_multipart([field1: {"value", size: 5}], boundary: "foo")
+
+      body = IO.iodata_to_binary(body)
+
+      assert size == byte_size(body)
+      assert content_type == "multipart/form-data; boundary=foo"
+
+      assert body == """
+             \r\n\
+             --foo\r\n\
+             content-disposition: form-data; name=\"field1\"\r\n\
+             \r\n\
+             value\r\n\
+             --foo--\r\n\
+             """
+    end
+
+    test "raise when size is not integer" do
+      assert_raise ArgumentError, fn ->
+        enum = Stream.cycle([1]) |> Stream.take(1)
+
+        Req.Utils.encode_form_multipart([field1: {enum, size: "not integer"}],
+          boundary: "foo"
+        )
+      end
+    end
+
+    test "can accept any enumerable" do
+      enum = Stream.cycle(["a"]) |> Stream.take(10)
+
+      %{body: body, size: size} =
+        Req.Utils.encode_form_multipart([field1: {enum, size: 10}], boundary: "foo")
+
+      body = body |> Enum.to_list() |> IO.iodata_to_binary()
+
+      assert size == byte_size(body)
+    end
+
+    test "blindly trust :content_length option" do
+      enum = Stream.cycle(["a"]) |> Stream.take(10)
+      advertised_length = 50
+
+      %{body: body, size: size} =
+        Req.Utils.encode_form_multipart([field1: {enum, size: advertised_length}],
+          boundary: "foo"
+        )
+
+      body = body |> Enum.to_list() |> IO.iodata_to_binary()
+
+      assert size ==
+               byte_size(body) + advertised_length - IO.iodata_length(enum |> Enum.to_list())
+    end
+
+    test "can return nil size" do
+      enum = Stream.cycle(["a"]) |> Stream.take(10)
+
+      %{size: size} =
+        Req.Utils.encode_form_multipart([field1: {enum, []}],
+          boundary: "foo"
+        )
+
+      assert size == nil
+    end
+
     @tag :tmp_dir
     test "can return stream", %{tmp_dir: tmp_dir} do
       File.write!("#{tmp_dir}/2.txt", "22")

--- a/test/req/utils_test.exs
+++ b/test/req/utils_test.exs
@@ -222,16 +222,6 @@ defmodule Req.UtilsTest do
              """
     end
 
-    test "raise when size is not integer" do
-      assert_raise ArgumentError, fn ->
-        enum = Stream.cycle([1]) |> Stream.take(1)
-
-        Req.Utils.encode_form_multipart([field1: {enum, size: "not integer"}],
-          boundary: "foo"
-        )
-      end
-    end
-
     test "can accept any enumerable" do
       enum = Stream.cycle(["a"]) |> Stream.take(10)
 


### PR DESCRIPTION
Closes #456 

- adds `:content_length` (maybe rename to `:size`?)
- the new option IS required when value type is `Enumerable`
- no validation :( users can craft requests with incorrect content-length header