### PR TITLE
retry_delay_in_ms: support float delays

### DIFF
--- a/lib/req/response.ex
+++ b/lib/req/response.ex
@@ -263,9 +263,11 @@ defmodule Req.Response do
   end
 
   defp retry_delay_in_ms(delay_value) do
-    case Integer.parse(delay_value) do
+    case Float.parse(delay_value) do
       {seconds, ""} ->
-        :timer.seconds(seconds)
+        seconds
+        |> :timer.seconds()
+        |> floor()
 
       :error ->
         delay_value


### PR DESCRIPTION
When retry delays were introduced in https://github.com/wojtekmach/req/pull/226 it was implied that the retry delay would be greater than or equal to 1s. In situations where retry delays are either passed back as floats and/or less than 1s, it would be nice to use full precision since we're converting to milliseconds anyway.

This specifically fixes a problem in my case where an API is consistently handing back retries that are less than 1s, i.e. 0.314s.