### PR TITLE
Fix Test.expect in shared mode

### DIFF
--- a/lib/req/test.ex
+++ b/lib/req/test.ex
@@ -363,7 +363,7 @@ defmodule Req.Test do
 
   def __fetch_plug__(name) do
     case Req.Test.Ownership.fetch_owner(@ownership, callers(), name) do
-      {:ok, owner} when is_pid(owner) ->
+      {tag, owner} when is_pid(owner) and tag in [:ok, :shared_owner] ->
         result =
           Req.Test.Ownership.get_and_update(@ownership, owner, name, fn
             %{expectations: [value | rest]} = map ->
@@ -378,17 +378,6 @@ defmodule Req.Test do
 
         case result do
           {:ok, {:ok, value}} ->
-            value
-
-          {:ok, {:error, :no_expectations_and_no_stub}} ->
-            raise "no mock or stub for #{inspect(name)}"
-        end
-
-      {:shared_owner, owner} when is_pid(owner) ->
-        result = Req.Test.Ownership.get_owned(@ownership, owner)[name]
-
-        case result do
-          %{stub: value} ->
             value
 
           {:ok, {:error, :no_expectations_and_no_stub}} ->

--- a/test/req/test_test.exs
+++ b/test/req/test_test.exs
@@ -21,11 +21,18 @@ defmodule Req.TestTest do
 
     assert Req.Test.__fetch_plug__(:foo) == {MyPlug, [2]}
 
-    Req.Test.stub(:bar, {SharedPlug, [1]})
     Req.Test.set_req_test_to_shared()
+    Req.Test.stub(:bar, {SharedPlug, [1]})
 
     Task.async(fn ->
       assert Req.Test.__fetch_plug__(:bar) == {SharedPlug, [1]}
+    end)
+    |> Task.await()
+
+    Req.Test.expect(:baz, {SharedPlug, [1]})
+
+    Task.async(fn ->
+      assert Req.Test.__fetch_plug__(:baz) == {SharedPlug, [1]}
     end)
     |> Task.await()
   after


### PR DESCRIPTION
This commit fixes
```elixir
Req.Test.set_req_test_to_shared()

Req.Test.expect(MyApp.Weather, fn conn ->
  Req.Test.json(conn, %{"celsius" => 25555.0})
end)

assert {:ok, %Req.Response{}} == Reqrepro.hello()
```

which would produce
```
     ** (CaseClauseError) no case clause matching: %{expectations: [#Function<0.11329399/1 in ReqreproTest."test test"/1>]}
     code: assert {:ok, %Req.Response{}} == Reqrepro.hello()
     stacktrace:
       (req 0.5.8) lib/req/test.ex:390: Req.Test.__fetch_plug__/1
       (req 0.5.8) lib/req/test.ex:632: Req.Test.call/2
       (req 0.5.8) lib/req/steps.ex:964: Req.Steps.run_plug/1
       (req 0.5.8) lib/req/request.ex:1106: Req.Request.run_request/1
       (req 0.5.8) lib/req/request.ex:1050: Req.Request.run/1
```
