### PR TITLE
Minor improvements to the documentation

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -312,6 +312,16 @@ defmodule Req do
 
     * `:max_redirects` - the maximum number of redirects, defaults to `10`.
 
+  Other response options:
+
+    * `:http_errors` - how to handle HTTP 4xx/5xx error responses (via
+      [`handle_http_errors`](`Req.Steps.handle_http_errors/1`) step).
+      Can be one of the following:
+
+      * `:return` (default) - return the response
+
+      * `:raise` - raise an error
+
   Retry options ([`retry`](`Req.Steps.retry/1`) step):
 
     * `:retry` - can be one of the following:

--- a/lib/req/test.ex
+++ b/lib/req/test.ex
@@ -55,7 +55,8 @@ defmodule Req.Test do
 
         def get_temperature(location) do
           [
-            base_url: "https://weather-service"
+            base_url: "https://weather-service",
+            params: [location: location]
           ]
           |> Keyword.merge(Application.get_env(:myapp, :weather_req_options, []))
           |> Req.request()


### PR DESCRIPTION
Hi @wojtekmach 👋

- fixes a small example to look more natural
- document the options from this [step](https://hexdocs.pm/req/Req.Steps.html#handle_http_errors/1) upstream

I also had a small question regarding [`default_options`](https://hexdocs.pm/req/Req.html#default_options/0): I noticed based on the implementation that it should be possible to set this from a config, but this is undocumented behavior so I didn't want to rely on it. Do you think this could this be officially documented?

(might avoid it anyway, I could totally understand the argument that such a global would be a smell, but given that the option exists and that it could streamline things in some non-library projects I figured I'd ask).