### PR TITLE
Refactor stream_gzip to use Stream.transform/5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: "1.13"
+              elixir: "1.14"
               otp: "24.3.4.10"
           - pair:
               elixir: "1.17"

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Req.MixProject do
     [
       app: :req,
       version: @version,
-      elixir: "~> 1.13",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),


### PR DESCRIPTION
As discussed.

https://hexdocs.pm/elixir/main/Stream.html#transform/5

A couple of other small changes:

- like [`:zlib.gzip`](https://github.com/erlang/otp/blob/OTP-27.3/erts/preloaded/src/zlib.erl#L757-L766), only `close` is called in the `after` block, `deflateEnd` is in the last block (I'm not sure if it is actually safer to prevent leaks, but it feels better to be be consistent with the original implementation)
- when checking the return of `deflate`, it can return a lot of `[]` -> I didn't benchmark but it feels cleaner to just not emit these - also see https://github.com/elixir-lang/elixir/pull/13793 for context