### PR TITLE
Fix leading newline before form multipart body

### DIFF
--- a/lib/req/utils.ex
+++ b/lib/req/utils.ex
@@ -506,7 +506,7 @@ defmodule Req.Utils do
       options[:boundary] ||
         Base.encode16(:crypto.strong_rand_bytes(16), padding: false, case: :lower)
 
-    footer = [[@crlf, "--", boundary, "--", @crlf]]
+    footer = [["--", boundary, "--", @crlf]]
 
     {body, size} =
       fields
@@ -586,8 +586,11 @@ defmodule Req.Utils do
       end
 
     headers = ["content-disposition: form-data; name=\"#{name}\"", params, @crlf, headers]
-    header = [[@crlf, "--", boundary, @crlf, headers, @crlf]]
-    add_form_parts({header, IO.iodata_length(header)}, {parts, parts_size})
+    header = [["--", boundary, @crlf, headers, @crlf]]
+
+    {header, IO.iodata_length(header)}
+    |> add_form_parts({parts, parts_size})
+    |> add_form_parts({@crlf, 2})
   end
 
   defp encode_form_part({name, value}, boundary) do

--- a/lib/req/utils.ex
+++ b/lib/req/utils.ex
@@ -590,7 +590,7 @@ defmodule Req.Utils do
 
     {header, IO.iodata_length(header)}
     |> add_form_parts({parts, parts_size})
-    |> add_form_parts({@crlf, 2})
+    |> add_form_parts({[@crlf], 2})
   end
 
   defp encode_form_part({name, value}, boundary) do

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -257,7 +257,7 @@ defmodule Req.StepsTest do
       plug = fn conn ->
         conn = Plug.Parsers.call(conn, Plug.Parsers.init(parsers: [:multipart]))
 
-        assert Plug.Conn.get_req_header(conn, "content-length") == ["393"]
+        assert Plug.Conn.get_req_header(conn, "content-length") == ["391"]
         assert %{"a" => "1", "b" => b, "c" => c} = conn.body_params
 
         assert b.filename == "b.txt"

--- a/test/req/utils_test.exs
+++ b/test/req/utils_test.exs
@@ -214,7 +214,6 @@ defmodule Req.UtilsTest do
       assert content_type == "multipart/form-data; boundary=foo"
 
       assert body == """
-             \r\n\
              --foo\r\n\
              content-disposition: form-data; name=\"field1\"\r\n\
              \r\n\
@@ -242,7 +241,6 @@ defmodule Req.UtilsTest do
       assert content_type == "multipart/form-data; boundary=foo"
 
       assert body == """
-             \r\n\
              --foo\r\n\
              content-disposition: form-data; name=\"field1\"\r\n\
              \r\n\
@@ -306,7 +304,6 @@ defmodule Req.UtilsTest do
       assert size == byte_size(body)
 
       assert body == """
-             \r\n\
              --foo\r\n\
              content-disposition: form-data; name=\"field1\"\r\n\
              \r\n\
@@ -333,7 +330,6 @@ defmodule Req.UtilsTest do
       assert size == byte_size(body)
 
       assert body == """
-             \r\n\
              --foo\r\n\
              content-disposition: form-data; name=\"field2\"; filename=\"2.txt\"\r\n\
              content-type: text/plain\r\n\


### PR DESCRIPTION
Currently on form multipart requests, an unnecessary extra CR/LF gets inserted after the request headers. The fix is to change this encoding pattern:

    [crlf part] [crlf part] [crlf footer]

To this pattern:

    [part crlf] [part crlf] [footer]