### PR TITLE
add a request_retry_modifier function that can modify a request object before a retry

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -354,6 +354,8 @@ defmodule Req do
 
             * `{:delay, milliseconds}` - retry with the given delay.
 
+            * `{:delay, milliseconds, request_retry_modifier}` - retry with the given delay. The request object is passed to the request_retry_modifier function immediately before each retry. This can be helpful, for example, if you need to update an auth header that is based on the current time.
+
             * `false/nil` - don't retry.
 
         * `false` - don't retry.

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1491,7 +1491,7 @@ defmodule Req.Steps do
   ## Options
 
     * `:raw` - if set to `true`, disables response body decompression. Defaults to `false`.
-    
+
       Note: setting `raw: true` also disables response body decoding in the `decode_body/1` step.
 
   ## Examples
@@ -2151,6 +2151,14 @@ defmodule Req.Steps do
                 "expected :retry_delay not to be set when the :retry function is returning `{:delay, milliseconds}`"
         end
 
+        {:delay, delay, request_retry_modifier} when is_function(request_retry_modifier) ->
+          if !Req.Request.get_option(request, :retry_delay) do
+            retry(request, response_or_exception, delay, request_retry_modifier)
+          else
+            raise ArgumentError,
+                  "expected :retry_delay not to be set when the :retry function is returning `{:delay, milliseconds, request_retry_modifier}`"
+          end
+
       true ->
         retry(request, response_or_exception)
 
@@ -2194,14 +2202,18 @@ defmodule Req.Steps do
   defp retry(request, response_or_exception, delay_or_nil \\ nil)
 
   defp retry(request, response_or_exception, nil) do
-    do_retry(request, response_or_exception, &get_retry_delay/3)
+    do_retry(request, response_or_exception, &get_retry_delay/3, fn request -> request end)
   end
 
   defp retry(request, response_or_exception, delay) when is_integer(delay) do
-    do_retry(request, response_or_exception, fn request, _, _ -> {request, delay} end)
+    do_retry(request, response_or_exception, fn request, _, _ -> {request, delay} end, fn request -> request end)
   end
 
-  defp do_retry(request, response_or_exception, delay_getter) do
+  defp retry(request, response_or_exception, delay, request_retry_modifier) when is_integer(delay) and is_function(request_retry_modifier) do
+    do_retry(request, response_or_exception, fn request, _, _ -> {request, delay} end, request_retry_modifier)
+  end
+
+  defp do_retry(request, response_or_exception, delay_getter, request_retry_modifier) when is_function(request_retry_modifier) do
     retry_count = Req.Request.get_private(request, :req_retry_count, 0)
     {request, delay} = delay_getter.(request, response_or_exception, retry_count)
     max_retries = Req.Request.get_option(request, :max_retries, 3)
@@ -2210,6 +2222,7 @@ defmodule Req.Steps do
     if retry_count < max_retries do
       log_retry(response_or_exception, retry_count, max_retries, delay, log_level)
       Process.sleep(delay)
+      request = request_retry_modifier.(request)
       request = Req.Request.put_private(request, :req_retry_count, retry_count + 1)
       {request, response_or_exception} = Req.Request.run_request(%{request | halted: false})
       Req.Request.halt(request, response_or_exception)


### PR DESCRIPTION
**Summary**

This PR implements my proposal in https://github.com/wojtekmach/req/issues/296#issuecomment-2972003597.

It introduces a new retry option:

`{:delay, milliseconds, request_retry_modifier}`

The request_retry_modifier is a function that is invoked **before a retry**. It receives the current request and returns a modified request.

**Why?**

Currently, Req does not re-run steps on retries. This new option provides an escape hatch for scenarios where request modification is needed on retry—for example, recomputing a time-based authentication header.

