### PR TITLE
Use a custom adapter for transitioning to automatic body reads

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -909,10 +909,11 @@ defmodule Req.Steps do
         * A _module_ plug: a `module` name or a `{module, options}` tuple.
 
       Req automatically calls `Plug.Conn.fetch_query_params/2` before your plug, so you can
-      get query params using `conn.query_params`. Req also automatically fetches the request
-      body using `Plug.Parsers` for JSON and multipart forms, you can get these using
-      `conn.body_params`. The raw request body of the request is available by calling
-      `Req.Test.raw_body/1` with the conn.
+      get query params using `conn.query_params`.
+
+      Req also automatically parses request body using `Plug.Parsers` for JSON, urlencoded and
+      multipart requests and you can access it with `conn.body_params`. The raw request body of
+      the request is available by calling `Req.Test.raw_body/1` with the `conn` in your tests.
 
   ## Examples
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1019,7 +1019,7 @@ defmodule Req.Steps do
         )
 
       conn =
-        Req.Test.PlugAdapter.conn(%Plug.Conn{}, request.method, request.url, req_body)
+        Req.Test.Adapter.conn(%Plug.Conn{}, request.method, request.url, req_body)
         |> Map.replace!(:req_headers, req_headers)
         |> Plug.Conn.fetch_query_params()
         |> Plug.Parsers.call(parser_opts)

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1020,7 +1020,7 @@ defmodule Req.Steps do
         )
 
       conn =
-        Plug.Test.conn(request.method, request.url, req_body)
+        Req.Test.PlugAdapter.conn(%Plug.Conn{}, request.method, request.url, req_body)
         |> Map.replace!(:req_headers, req_headers)
         |> Plug.Conn.fetch_query_params()
         |> Plug.Parsers.call(parser_opts)

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1023,7 +1023,6 @@ defmodule Req.Steps do
         |> Map.replace!(:req_headers, req_headers)
         |> Plug.Conn.fetch_query_params()
         |> Plug.Parsers.call(parser_opts)
-        |> Plug.Conn.put_private(:req_test_raw_body, req_body)
 
       # Handle cases where the body isn't read with Plug.Parsers
       {mod, state} = conn.adapter

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1024,7 +1024,20 @@ defmodule Req.Steps do
         |> Map.replace!(:req_headers, req_headers)
         |> Plug.Conn.fetch_query_params()
         |> Plug.Parsers.call(parser_opts)
-        |> call_plug(plug)
+
+      # Handle cases where the body isn't read with Plug.Parsers
+      {mod, state} = conn.adapter
+      state = %{state | body_read: true}
+      conn = %{conn | adapter: {mod, state}}
+
+      conn =
+        if !conn.private[:req_test_raw_body] do
+          Plug.Conn.put_private(conn, :req_test_raw_body, req_body)
+        else
+          conn
+        end
+
+      conn = call_plug(conn, plug)
 
       unless match?(%Plug.Conn{}, conn) do
         raise ArgumentError, "expected to return %Plug.Conn{}, got: #{inspect(conn)}"

--- a/lib/req/test.ex
+++ b/lib/req/test.ex
@@ -743,7 +743,7 @@ defmodule Req.Test do
   if Code.ensure_loaded?(Plug.Test) do
     @spec raw_body(Plug.Conn.t()) :: iodata()
     def raw_body(%Plug.Conn{} = conn) do
-      {Req.Test.PlugAdapter, %{raw_body: raw_body}} = conn.adapter
+      {Req.Test.Adapter, %{raw_body: raw_body}} = conn.adapter
       raw_body
     end
   else

--- a/lib/req/test.ex
+++ b/lib/req/test.ex
@@ -725,16 +725,6 @@ defmodule Req.Test do
     end
   end
 
-  ## Plug Parser
-
-  @doc false
-  def __read_request_body__(conn, opts) do
-    with {:ok, body, conn} <- Plug.Conn.read_body(conn, opts) do
-      conn = update_in(conn.private[:req_test_raw_body], &((&1 || "") <> body))
-      {:ok, body, conn}
-    end
-  end
-
   @doc """
   Reads the raw request body from a plug request.
 
@@ -753,7 +743,8 @@ defmodule Req.Test do
   if Code.ensure_loaded?(Plug.Test) do
     @spec raw_body(Plug.Conn.t()) :: iodata()
     def raw_body(%Plug.Conn{} = conn) do
-      conn.private.req_test_raw_body
+      {Req.Test.PlugAdapter, %{raw_body: raw_body}} = conn.adapter
+      raw_body
     end
   else
     def raw_body(_conn) do

--- a/lib/req/test/adapter.ex
+++ b/lib/req/test/adapter.ex
@@ -1,4 +1,4 @@
-defmodule Req.Test.PlugAdapter do
+defmodule Req.Test.Adapter do
   @behaviour Plug.Conn.Adapter
   @moduledoc false
 

--- a/lib/req/test/adapter.ex
+++ b/lib/req/test/adapter.ex
@@ -1,0 +1,40 @@
+defmodule Req.Test.PlugAdapter do
+  @behaviour Plug.Conn.Adapter
+  @moduledoc false
+
+  ## Test helpers
+
+  def conn(conn, method, uri, body_or_params) do
+    conn = Plug.Adapters.Test.Conn.conn(conn, method, uri, body_or_params)
+    {_, state} = conn.adapter
+    state = Map.merge(state, %{has_more_body: false})
+    %{conn | adapter: {__MODULE__, state}}
+  end
+
+  ## Connection adapter
+  def read_req_body(state, opts \\ []) do
+    # We restore the body for the first automatic read for backwards
+    # compatability with Req 0.5.10 and below.
+    # TODO: remove in 0.6 if we allow opting out
+    case Plug.Adapters.Test.Conn.read_req_body(state, opts) do
+      {:more, body, state} ->
+        {:more, body, %{state | has_more_body: true}}
+
+      {:ok, body, %{has_more_body: true} = state} ->
+        {:ok, body, state}
+
+      {:ok, body, state} ->
+        {:ok, body, %{state | req_body: body}}
+    end
+  end
+
+  defdelegate send_resp(state, status, headers, body), to: Plug.Adapters.Test.Conn
+  defdelegate send_file(state, status, headers, path, offset, length), to: Plug.Adapters.Test.Conn
+  defdelegate send_chunked(state, status, headers), to: Plug.Adapters.Test.Conn
+  defdelegate chunk(state, body), to: Plug.Adapters.Test.Conn
+  defdelegate inform(state, status, headers), to: Plug.Adapters.Test.Conn
+  defdelegate upgrade(state, protocol, opts), to: Plug.Adapters.Test.Conn
+  defdelegate push(state, path, headers), to: Plug.Adapters.Test.Conn
+  defdelegate get_peer_data(payload), to: Plug.Adapters.Test.Conn
+  defdelegate get_http_protocol(payload), to: Plug.Adapters.Test.Conn
+end

--- a/lib/req/test/adapter.ex
+++ b/lib/req/test/adapter.ex
@@ -4,10 +4,10 @@ defmodule Req.Test.PlugAdapter do
 
   ## Test helpers
 
-  def conn(conn, method, uri, body_or_params) do
-    conn = Plug.Adapters.Test.Conn.conn(conn, method, uri, body_or_params)
+  def conn(conn, method, uri, body) when is_binary(body) do
+    conn = Plug.Adapters.Test.Conn.conn(conn, method, uri, body)
     {_, state} = conn.adapter
-    state = Map.merge(state, %{body_read: false, has_more_body: false})
+    state = Map.merge(state, %{body_read: false, has_more_body: false, raw_body: body})
     %{conn | adapter: {__MODULE__, state}}
   end
 

--- a/test/req/adapter_test.exs
+++ b/test/req/adapter_test.exs
@@ -50,4 +50,16 @@ defmodule Req.AdapterTest do
 
     assert Req.post!(plug: plug, json: %{a: 1}).body == "ok"
   end
+
+  test "reading binary body" do
+    plug = fn conn ->
+      {:ok, "foo", conn} = Plug.Conn.read_body(conn)
+      {:ok, "", conn} = Plug.Conn.read_body(conn)
+      assert Req.Test.raw_body(conn) == "foo"
+      assert Req.Test.raw_body(conn) == "foo"
+      Plug.Conn.send_resp(conn, 200, "ok")
+    end
+
+    assert Req.post!(plug: plug, body: "foo").body == "ok"
+  end
 end

--- a/test/req/adapter_test.exs
+++ b/test/req/adapter_test.exs
@@ -1,0 +1,53 @@
+defmodule Req.AdapterTest do
+  use ExUnit.Case, async: true
+
+  test "reading request body" do
+    plug = fn conn ->
+      {:ok, "{\"a\":1}", conn} = Plug.Conn.read_body(conn)
+      assert conn.body_params == %{"a" => 1}
+      assert Req.Test.raw_body(conn) == "{\"a\":1}"
+      Plug.Conn.send_resp(conn, 200, "ok")
+    end
+
+    assert Req.post!(plug: plug, json: %{a: 1}).body == "ok"
+  end
+
+  test "partially reading body" do
+    plug = fn conn ->
+      {:more, "{", conn} = Plug.Conn.read_body(conn, length: 1)
+      {:more, "\"", conn} = Plug.Conn.read_body(conn, length: 1)
+      {:more, "a\"", conn} = Plug.Conn.read_body(conn, length: 2)
+      {:more, ":", conn} = Plug.Conn.read_body(conn, length: 1)
+      {:ok, "1}", conn} = Plug.Conn.read_body(conn)
+      # We're done here
+      {:ok, "", conn} = Plug.Conn.read_body(conn)
+
+      assert conn.body_params == %{"a" => 1}
+      assert Req.Test.raw_body(conn) == "{\"a\":1}"
+      Plug.Conn.send_resp(conn, 200, "ok")
+    end
+
+    assert Req.post!(plug: plug, json: %{a: 1}).body == "ok"
+  end
+
+  test "fetches request with parsers" do
+    plug = fn conn ->
+      parser_opts =
+        Plug.Parsers.init(
+          parsers: [:urlencoded, :multipart, :json],
+          pass: ["*/*"],
+          json_decoder: Jason,
+          body_reader: {Req.Test, :__read_request_body__, []}
+        )
+
+      conn = Plug.Parsers.call(conn, parser_opts)
+
+      {:ok, "{\"a\":1}", conn} = Plug.Conn.read_body(conn)
+      assert conn.body_params == %{"a" => 1}
+      assert Req.Test.raw_body(conn) == "{\"a\":1}"
+      Plug.Conn.send_resp(conn, 200, "ok")
+    end
+
+    assert Req.post!(plug: plug, json: %{a: 1}).body == "ok"
+  end
+end

--- a/test/req/test/adapter_test.exs
+++ b/test/req/test/adapter_test.exs
@@ -1,4 +1,4 @@
-defmodule Req.AdapterTest do
+defmodule Req.Test.AdapterTest do
   use ExUnit.Case, async: true
 
   test "reading request body" do


### PR DESCRIPTION
In commit c17cd20 using `run_plug` was modified to ensure that the body was read. This was much more convenient for tests that assert on body_params for JSON or file uploads, however it could break existing tests that were using `read_body` directly.

This commit adds a custom adapter that supports calling read_body, however it warns the user. The body is cached in the custom adapter, and re-populates the body when reading, to ensure that the existing `read_body` options work.

In a future commit, we should add the ability to opt-out of the automatic parsing, which would inform the custom adapter to simply delegate to the `Plug.Adapters.Test.Conn` adapter.