### PR TITLE
fix: fully encode path_params even with reserved characters

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -544,7 +544,7 @@ defmodule Req.Steps do
         Regex.replace(regex, path, fn match, key ->
           case params[String.to_existing_atom(key)] do
             nil -> match
-            value -> value |> to_string() |> URI.encode()
+            value -> value |> to_string() |> URI.encode(&URI.char_unreserved?/1)
           end
         end)
     end)
@@ -1493,7 +1493,7 @@ defmodule Req.Steps do
   ## Options
 
     * `:raw` - if set to `true`, disables response body decompression. Defaults to `false`.
-    
+
       Note: setting `raw: true` also disables response body decoding in the `decode_body/1` step.
 
   ## Examples

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -329,6 +329,21 @@ defmodule Req.StepsTest do
     assert URI.to_string(req.url) == "http://foo/abc%7Cdef:bar"
   end
 
+  test "put_path_params properly escapes reserved characters" do
+    req =
+      Req.new(url: "http://foo/:id{ola}", path_params: [id: "abc#def"]) |> Req.Request.prepare()
+
+    assert URI.to_string(req.url) == "http://foo/abc%23def{ola}"
+
+    # With :curly style.
+
+    req =
+      Req.new(url: "http://foo/{id}:bar", path_params: [id: "abc#def"], path_params_style: :curly)
+      |> Req.Request.prepare()
+
+    assert URI.to_string(req.url) == "http://foo/abc%23def:bar"
+  end
+
   test "put_range" do
     req = Req.new(range: "bytes=0-10") |> Req.Request.prepare()
     assert Req.Request.get_header(req, "range") == ["bytes=0-10"]


### PR DESCRIPTION
Fixes #488 

This pull request enhances URI encoding in the `Req` library by ensuring reserved characters are properly escaped and adds corresponding test cases to verify this behavior.

### Improvements to URI encoding:

* [`lib/req/steps.ex`](diffhunk://#diff-07dc6fd4ec95415d610a3e3ddf9374540d6d64d02eaf42df7a233d6f05b32cc1L547-R547): Updated the `URI.encode` call to use the `URI.char_unreserved?/1` function, ensuring proper handling of reserved characters during URI encoding.

### Additional test coverage:

* [`test/req/steps_test.exs`](diffhunk://#diff-dc476e4c9226d38862002c18df4835a1d51d98448df84548cd4e144fae0ec2e9R332-R346): Added a new test, `put_path_params properly escapes reserved characters`, to validate that reserved characters (e.g., `#`) are correctly escaped in both default and curly path parameter styles.