### PR TITLE
Support non-utf8 request params in Req.Test

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1071,7 +1071,7 @@ defmodule Req.Steps do
       conn =
         Req.Test.Adapter.conn(%Plug.Conn{}, request.method, request.url, req_body)
         |> Map.replace!(:req_headers, req_headers)
-        |> Plug.Conn.fetch_query_params()
+        |> Plug.Conn.fetch_query_params(validate_utf8: false)
         |> Plug.Conn.put_private(:req_private, request.private)
         |> Plug.Parsers.call(parser_opts)
 

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -2226,10 +2226,11 @@ defmodule Req.StepsTest do
       plug = fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
         assert body == ~s|{"a":1}|
+        assert conn.query_params == %{"foo" => <<0xFF>>}
         Plug.Conn.send_resp(conn, 200, "ok")
       end
 
-      assert Req.request!(plug: plug, json: %{a: 1}).body == "ok"
+      assert Req.request!(plug: plug, json: %{a: 1}, params: %{foo: <<0xFF>>}).body == "ok"
       refute_receive _
     end
 


### PR DESCRIPTION
I have a use case for sending non-utf8 query parameters (specifically, announcing to BitTorrent trackers from a BitTorrent client). I'm using Req.Test to assert against the request payload my application sends, and am hitting an error of the form "invalid UTF-8 on urlencoded params, got byte...".

This commit disables utf8 validation on Req.Test's plug. I am not 100% sure, but I don't _think_ this will break anything else (well, apart from implicit utf8-validation of query parameters, but explicit test assertions on the values / pattern-matching should cover most use cases). If desired, we can perhaps make it an option.