### PR TITLE
Include Private Data in Plug Connection

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1023,6 +1023,7 @@ defmodule Req.Steps do
         Req.Test.Adapter.conn(%Plug.Conn{}, request.method, request.url, req_body)
         |> Map.replace!(:req_headers, req_headers)
         |> Plug.Conn.fetch_query_params()
+        |> Plug.Conn.put_private(:req_private, request.private)
         |> Plug.Parsers.call(parser_opts)
 
       # Handle cases where the body isn't read with Plug.Parsers


### PR DESCRIPTION
Hello 👋🏼 

This is a proposal / for discussion purposes, but it was easier to demonstrate the proposal in code rather than as an issue.

Would you consider forwarding some of the original request data to the `conn` struct created by `run_plug`? Doing so could enable advanced testing workflows by client libraries that utilize Req. Perhaps there is other, similar data from the original request that is worth including as well.

Thanks for your consideration! ❤️ 