### PR TITLE
`run_finch`: Support Finch request timeout option

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -422,10 +422,13 @@ defmodule Req do
 
     * `:receive_timeout` - socket receive timeout in milliseconds, defaults to `15_000`.
 
+    * `:request_timeout` - response timeout in milliseconds, defaults to `:infinity`.
+      See `Finch.request/3`.
+
     * `:unix_socket` - if set, connect through the given UNIX domain socket.
 
     * `:pool_max_idle_time` - the maximum number of milliseconds that a pool can be
-      idle before being terminated, used only by HTTP1 pools. Default to `:infinity`.
+      idle before being terminated, used only by HTTP1 pools. Defaults to `:infinity`.
 
     * `:finch_private` - a map or keyword list of private metadata to add to the Finch request. May be useful
       for adding custom data when handling telemetry with `Finch.Telemetry`.

--- a/lib/req/finch.ex
+++ b/lib/req/finch.ex
@@ -47,7 +47,9 @@ defmodule Req.Finch do
       |> add_private_options(request.options[:finch_private])
 
     finch_options =
-      request.options |> Map.take([:receive_timeout, :pool_timeout]) |> Enum.to_list()
+      request.options
+      |> Map.take([:receive_timeout, :pool_timeout, :request_timeout])
+      |> Enum.to_list()
 
     run(request, finch_request, finch_name, finch_options)
   end

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -801,6 +801,9 @@ defmodule Req.Steps do
 
     * `:receive_timeout` - socket receive timeout in milliseconds, defaults to `15_000`.
 
+    * `:request_timeout` - response timeout in milliseconds, defaults to `:infinity`.
+      See `Finch.request/3`.
+
     * `:unix_socket` - if set, connect through the given UNIX domain socket.
 
     * `:pool_max_idle_time` - the maximum number of milliseconds that a pool can be

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -56,6 +56,7 @@ defmodule Req.Steps do
       :finch_private,
       :connect_options,
       :inet6,
+      :request_timeout,
       :receive_timeout,
       :pool_timeout,
       :unix_socket,


### PR DESCRIPTION
Allow passing the `:request_timeout` option to `Finch.request`.