### PR TITLE
Fix Retry-After header parsing for decimal seconds

### DIFF
--- a/lib/req/response.ex
+++ b/lib/req/response.ex
@@ -247,9 +247,9 @@ defmodule Req.Response do
   end
 
   defp retry_delay_in_ms(delay_value) do
-    case Integer.parse(delay_value) do
+    case Float.parse(delay_value) do
       {seconds, ""} ->
-        :timer.seconds(seconds)
+        round(:timer.seconds(seconds))
 
       :error ->
         delay_value

--- a/test/req/response_test.exs
+++ b/test/req/response_test.exs
@@ -1,4 +1,35 @@
 defmodule Req.ResponseTest do
   use ExUnit.Case, async: true
   doctest Req.Response, except: [get_header: 2, delete_header: 2]
+
+  describe "get_retry_after/1" do
+    test "parses integer retry-after values" do
+      response = Req.Response.new(headers: [{"retry-after", "5"}])
+      assert Req.Response.get_retry_after(response) == 5000
+    end
+
+    test "parses decimal retry-after values" do
+      response = Req.Response.new(headers: [{"retry-after", "2.0"}])
+      assert Req.Response.get_retry_after(response) == 2000
+    end
+
+    test "handles edge cases" do
+      response = Req.Response.new(headers: [{"retry-after", "0.0"}])
+      assert Req.Response.get_retry_after(response) == 0
+    end
+
+    test "returns nil when retry-after header is not present" do
+      response = Req.Response.new()
+      assert Req.Response.get_retry_after(response) == nil
+    end
+
+    test "parses HTTP date retry-after values" do
+      future_date = DateTime.utc_now() |> DateTime.add(60, :second)
+      http_date = Req.Utils.format_http_date(future_date)
+      response = Req.Response.new(headers: [{"retry-after", http_date}])
+
+      result = Req.Response.get_retry_after(response)
+      assert_in_delta result, 60000, 1000
+    end
+  end
 end


### PR DESCRIPTION
Req crashed with a CaseClauseError when encountering `Retry-After` headers containing decimal seconds (e.g., `Retry-After: 2.0` f.e. [by Shopify](https://shopify.dev/docs/api/admin-rest/usage/rate-limits#retry-after-header)). These are according to spec here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After

The parsing logic used `Integer.parse/1` which returns `{2, ".0"}` for `"2.0"`, but the case statement only expected `{seconds, ""}` for valid integers.

- Replaced `Integer.parse/1` with `Float.parse/1` to handle both integer and decimal values
- Added `Kernel.round()` to ensure millisecond values remain integers
- Maintains full backward compatibility with existing integer and HTTP date parsing

