### PR TITLE
Support non-utf8-encoded query parameters in Req.Test

### DIFF
--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1000,6 +1000,15 @@ defmodule Req.Steps do
     def run_plug(request) do
       plug = request.options.plug
 
+      validate_utf8_query =
+        case plug do
+          {Req.Test, opts} when is_list(opts) ->
+            Keyword.get(opts, :validate_utf8_query, true)
+
+          _ ->
+            true
+        end
+
       req_body =
         case request.body do
           iodata when is_binary(iodata) or is_list(iodata) ->
@@ -1032,7 +1041,7 @@ defmodule Req.Steps do
       conn =
         Req.Test.Adapter.conn(%Plug.Conn{}, request.method, request.url, req_body)
         |> Map.replace!(:req_headers, req_headers)
-        |> Plug.Conn.fetch_query_params()
+        |> Plug.Conn.fetch_query_params(validate_utf8: validate_utf8_query)
         |> Plug.Parsers.call(parser_opts)
 
       # Handle cases where the body isn't read with Plug.Parsers

--- a/lib/req/test.ex
+++ b/lib/req/test.ex
@@ -723,12 +723,19 @@ defmodule Req.Test do
   end
 
   @doc false
-  def init(name) do
-    name
+  def init(opts) when is_list(opts) do
+    opts
   end
 
   @doc false
-  def call(conn, name) do
+  def init(name) do
+    init(name: name)
+  end
+
+  @doc false
+  def call(conn, opts) do
+    name = Keyword.fetch!(opts, :name)
+
     case __fetch_plug__(name) do
       fun when is_function(fun, 1) ->
         fun.(conn)

--- a/test/req/test_test.exs
+++ b/test/req/test_test.exs
@@ -109,6 +109,18 @@ defmodule Req.TestTest do
       Req.Test.stub(:foo, {Foo, "hi"})
       assert Req.get!(plug: {Req.Test, :foo}).body == "hi"
     end
+
+    test "extended configuration" do
+      Req.Test.stub(:accepts_non_utf8_query, fn conn ->
+        assert conn.query_params == %{"foo" => <<0xFF>>}
+        Plug.Conn.send_resp(conn, 200, "ok")
+      end)
+
+      assert Req.get!(
+               plug: {Req.Test, name: :accepts_non_utf8_query, validate_utf8_query: false},
+               params: %{foo: <<0xFF>>}
+             ).body == "ok"
+    end
   end
 
   describe "allow/3" do


### PR DESCRIPTION
Alternative to https://github.com/wojtekmach/req/pull/495

Draft to get initial feedback, I'm happy to update the docs here if this is on the right track