### PR TITLE
Fix bug when Req.Test.__fetch_plug__/1 called after mode set to shared

### DIFF
--- a/lib/req/test.ex
+++ b/lib/req/test.ex
@@ -478,6 +478,9 @@ defmodule Req.Test do
 
             %{expectations: []} = map ->
               {{:error, :no_expectations_and_no_stub}, map}
+
+            nil ->
+              {{:error, :no_expectations_and_no_stub}, %{}}
           end)
 
         case result do


### PR DESCRIPTION
If `Req.Test.__fetch_plug__/1` is called immediately after the ownership mode is set to shared as follows:
```elixir
Req.Test.set_req_test_to_shared()
Req.Test.__fetch_plug__(:foo)
```

the following error will be thrown, causing the ownership server to die:

    ** (exit) exited in: GenServer.call(Req.Test.Ownership, {:get_and_update, #PID<0.265.0>, :foo, #Function<0.28971161/1 in Req.Test.__fetch_plug__/1>}, 5000)
       ** (EXIT) an exception was raised:
	 ** (FunctionClauseError) no function clause matching in anonymous fn/1 in Req.Test.__fetch_plug__/1

	 The following arguments were given to anonymous fn/1 in Req.Test.__fetch_plug__/1:

	     # 1
	     nil

	 stacktrace:
	   (req 0.5.17) lib/req/test.ex:472: anonymous fn/1 in Req.Test.__fetch_plug__/1
	   (req 0.5.17) lib/req/test/ownership.ex:202: Req.Test.Ownership.handle_call/3
	   (stdlib 6.2) gen_server.erl:2381: :gen_server.try_handle_call/4
	   (stdlib 6.2) gen_server.erl:2410: :gen_server.handle_msg/6
	   (stdlib 6.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3

    stacktrace:
      (elixir 1.18.1) lib/gen_server.ex:1128: GenServer.call/3
      (req 0.5.17) lib/req/test/ownership.ex:59: Req.Test.Ownership.get_and_update/5
      (req 0.5.17) lib/req/test.ex:472: Req.Test.__fetch_plug__/1


The typespec for `Req.Test.Ownership.get_and_update/5`[^1] details that the function `fun` can handle `nil` as an argument:

```elixir
@spec get_and_update(server(), pid(), key(), fun, timeout()) ::
	{:ok, get_value} | {:error, Error.t()}
      when fun: (nil | metadata() -> {get_value, updated_metadata :: metadata()}),
	   get_value: term()
```

However, the function supplied to `Req.Test.Ownership.get_and_update/5` in `Req.Test.__fetch_plug__`[^2] cannot handle a `nil` argument:

```elixir
Req.Test.Ownership.get_and_update(@ownership, owner, name, fn
  %{expectations: [value | rest]} = map ->
    {{:ok, value}, put_in(map[:expectations], rest)}

  %{stub: value} = map ->
    {{:ok, value}, map}

  %{expectations: []} = map ->
    {{:error, :no_expectations_and_no_stub}, map}
```

A `FunctionClauseError` will be raised if `nil` is given to the function - which will occur when `pid` does not own the key[^3].

Given the above, handle a `nil` argument by returning a `:no_expectations_and_no_stub` tuple.

[^1]: https://github.com/wojtekmach/req/blob/dce10092b9f3b77dfa253e62a51534e8281ba0ba/lib/req/test/ownership.ex#L55
[^2]: https://github.com/wojtekmach/req/blob/dce10092b9f3b77dfa253e62a51534e8281ba0ba/lib/req/test.ex#L472-L480
[^3]: From the vendored library documentation: https://hexdocs.pm/nimble_ownership/1.0.1/NimbleOwnership.html#get_and_update/5-usage