### PR TITLE
Fix (extremely) minor typo in function doc

### DIFF
--- a/lib/req/request.ex
+++ b/lib/req/request.ex
@@ -1058,7 +1058,7 @@ defmodule Req.Request do
   end
 
   @doc """
-  Registers options to be used by a custom steps.
+  Registers options to be used by custom steps.
 
   Req ensures that all used options were previously registered which helps
   finding accidentally mistyped option names. If you're adding custom steps


### PR DESCRIPTION
Specific patch corresponds to documentation for `Req.Request.register_options/2`.

Found as I was perusing documentation 🔍