### PR TITLE
fix: allow :finch option with IPv6 URLs

### DIFF
--- a/lib/req/finch.ex
+++ b/lib/req/finch.ex
@@ -403,7 +403,7 @@ defmodule Req.Finch do
 
     cond do
       name = request.options[:finch] ->
-        if custom_options? do
+        if Map.has_key?(request.options, :connect_options) do
           raise ArgumentError, "cannot set both :finch and :connect_options"
         else
           name

--- a/test/req/finch_test.exs
+++ b/test/req/finch_test.exs
@@ -214,6 +214,45 @@ defmodule Req.FinchTest do
       end
     end
 
+    test ":finch and :inet6" do
+      # :inet6 can be auto-set for IPv6 URLs; it should not conflict with :finch
+      assert_raise ArgumentError, "unknown registry: MyFinch", fn ->
+        Req.get!("http://localhost", finch: MyFinch, inet6: true)
+      end
+    end
+
+    test ":finch with IPv6 URL" do
+      start_supervised!(
+        {Plug.Cowboy,
+         scheme: :http,
+         plug: ExamplePlug,
+         ref: ExamplePlug.IPv6Named,
+         port: 0,
+         net: :inet6,
+         ipv6_v6only: true}
+      )
+
+      ipv6_port = :ranch.get_port(ExamplePlug.IPv6Named)
+
+      finch_name = __MODULE__.IPv6Finch
+
+      start_supervised!(
+        {Finch,
+         name: finch_name,
+         pools: %{
+           default: [
+             protocols: [:http1],
+             conn_opts: [transport_opts: [inet6: true]]
+           ]
+         }}
+      )
+
+      # Before the fix, this would raise "cannot set both :finch and :connect_options"
+      # because Req auto-sets inet6: true for IPv6 URLs like [::1]
+      req = Req.new(url: "http://[::1]:#{ipv6_port}", finch: finch_name)
+      assert Req.request!(req).body == "ok"
+    end
+
     def send_telemetry_metadata_pid(_name, _measurements, metadata, _) do
       if pid = metadata.request.private[:pid] do
         send(pid, :telemetry_private)

--- a/test/req/finch_test.exs
+++ b/test/req/finch_test.exs
@@ -214,13 +214,6 @@ defmodule Req.FinchTest do
       end
     end
 
-    test ":finch and :inet6" do
-      # :inet6 can be auto-set for IPv6 URLs; it should not conflict with :finch
-      assert_raise ArgumentError, "unknown registry: MyFinch", fn ->
-        Req.get!("http://localhost", finch: MyFinch, inet6: true)
-      end
-    end
-
     test ":finch with IPv6 URL" do
       start_supervised!(
         {Plug.Cowboy,
@@ -247,10 +240,12 @@ defmodule Req.FinchTest do
          }}
       )
 
-      # Before the fix, this would raise "cannot set both :finch and :connect_options"
-      # because Req auto-sets inet6: true for IPv6 URLs like [::1]
+      # :inet6 can be auto-set for IPv6 URLs; it should not conflict with :finch
       req = Req.new(url: "http://[::1]:#{ipv6_port}", finch: finch_name)
       assert Req.request!(req).body == "ok"
+
+      assert Req.request!("http://localhost:#{ipv6_port}", finch: finch_name, inet6: true).body ==
+               "ok"
     end
 
     def send_telemetry_metadata_pid(_name, _measurements, metadata, _) do


### PR DESCRIPTION
Req auto-sets `inet6: true` when the URL host contains `:` (e.g.
`http://[::1]:8080/`). The `finch_name/1` guard treated `:inet6` as a
custom pool option, causing it to raise "cannot set both :finch and
:connect_options" when a named Finch pool was also provided.

Narrow the guard to only reject `:connect_options`, which would
genuinely be ignored by a pre-configured Finch instance. The `:inet6`
flag is orthogonal to pool selection and should not conflict.

This fixes connection pool isolation for services that use separate
named Finch pools when the target is an IPv6 address.