### PR TITLE
Support Finch tagged pools via :finch option tuple

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -441,6 +441,16 @@ defmodule Req do
   Finch options ([`run_finch`](`Req.Steps.run_finch/1`) step), see `Finch.start_link/1` for options:
 
     * `:finch` - the Finch pool to use. Defaults to pool automatically started by `Req`.
+      Can be either a pool name (atom) or a `{name, opts}` tuple where `opts` can include:
+
+        * `:pool_tag` - the tag to use when selecting which Finch pool to use for a request.
+          Defaults to `:default`. This allows routing requests to different pools for the same
+          host. See `Finch.Pool.new/2` for more information on configuring tagged pools.
+
+      Examples:
+
+          Req.get!("https://api.example.com/data", finch: MyFinch)
+          Req.get!("https://api.example.com/data", finch: {MyFinch, pool_tag: :bulk})
 
     * `:connect_options` - dynamically starts (or re-uses already started) Finch pool with
       the given connection options (see `Mint.HTTP.connect/4` for options):
@@ -470,10 +480,6 @@ defmodule Req do
       See `Finch.request/3`.
 
     * `:unix_socket` - if set, connect through the given UNIX domain socket.
-
-    * `:pool_tag` - the tag to use when selecting which Finch pool to use for a request.
-      Defaults to `:default`. This allows routing requests to different pools for the same
-      host. See `Finch.Pool.new/2` for more information on configuring tagged pools.
 
     * `:pool_max_idle_time` - the maximum number of milliseconds that a pool can be
       idle before being terminated, used only by HTTP1 pools. Defaults to `:infinity`.

--- a/lib/req.ex
+++ b/lib/req.ex
@@ -443,9 +443,10 @@ defmodule Req do
     * `:finch` - the Finch pool to use. Defaults to pool automatically started by `Req`.
       Can be either a pool name (atom) or a `{name, opts}` tuple where `opts` can include:
 
-        * `:pool_tag` - the tag to use when selecting which Finch pool to use for a request.
-          Defaults to `:default`. This allows routing requests to different pools for the same
-          host. See `Finch.Pool.new/2` for more information on configuring tagged pools.
+        * `:pool_tag` - (requires Finch v0.22+) the tag to use when selecting which Finch pool to
+          use for a request. Defaults to `:default`. This allows routing requests to different
+          pools for the same host. See `Finch.Pool.new/2` for more information on configuring
+          tagged pools.
 
       Examples:
 

--- a/lib/req.ex
+++ b/lib/req.ex
@@ -471,6 +471,10 @@ defmodule Req do
 
     * `:unix_socket` - if set, connect through the given UNIX domain socket.
 
+    * `:pool_tag` - the tag to use when selecting which Finch pool to use for a request.
+      Defaults to `:default`. This allows routing requests to different pools for the same
+      host. See `Finch.Pool.new/2` for more information on configuring tagged pools.
+
     * `:pool_max_idle_time` - the maximum number of milliseconds that a pool can be
       idle before being terminated, used only by HTTP1 pools. Defaults to `:infinity`.
 

--- a/lib/req/finch.ex
+++ b/lib/req/finch.ex
@@ -76,9 +76,13 @@ defmodule Req.Finch do
           {:stream, enumerable}
       end
 
+    build_opts =
+      request.options
+      |> Map.take([:unix_socket, :pool_tag])
+      |> Enum.to_list()
+
     finch_request =
-      Finch.build(request.method, request.url, request_headers, body)
-      |> Map.replace!(:unix_socket, request.options[:unix_socket])
+      Finch.build(request.method, request.url, request_headers, body, build_opts)
       |> add_private_options(request.options[:finch_private])
 
     finch_options =

--- a/lib/req/finch.ex
+++ b/lib/req/finch.ex
@@ -19,7 +19,7 @@ defmodule Req.Finch do
         request
       end
 
-    finch_name = finch_name(request)
+    {finch_name, options} = finch_name_options(request)
 
     # TODO: Remove when :finch_request is removed
     if match?(
@@ -76,10 +76,15 @@ defmodule Req.Finch do
           {:stream, enumerable}
       end
 
-    build_opts = finch_build_opts(request)
+    options =
+      if unix_socket = request.options[:unix_socket] do
+        Keyword.put(options, :unix_socket, unix_socket)
+      else
+        options
+      end
 
     finch_request =
-      Finch.build(request.method, request.url, request_headers, body, build_opts)
+      Finch.build(request.method, request.url, request_headers, body, options)
       |> add_private_options(request.options[:finch_private])
 
     finch_options =
@@ -412,40 +417,12 @@ defmodule Req.Finch do
     end
   end
 
-  defp finch_build_opts(request) do
-    pool_tag_opts =
-      case request.options[:finch] do
-        {_name, opts} when is_list(opts) ->
-          Keyword.take(opts, [:pool_tag])
-
-        _ ->
-          []
-      end
-
-    unix_socket_opts =
-      request.options
-      |> Map.take([:unix_socket])
-      |> Enum.to_list()
-
-    pool_tag_opts ++ unix_socket_opts
-  end
-
-  defp finch_name(request) do
+  defp finch_name_options(request) do
     custom_options? =
       Map.has_key?(request.options, :connect_options) or Map.has_key?(request.options, :inet6)
 
-    cond do
-      finch_opt = request.options[:finch] ->
-        if Map.has_key?(request.options, :connect_options) do
-          raise ArgumentError, "cannot set both :finch and :connect_options"
-        end
-
-        case finch_opt do
-          {name, _opts} -> name
-          name -> name
-        end
-
-      custom_options? ->
+    case request.options[:finch] do
+      nil when custom_options? ->
         pool_options = pool_options(request.options)
 
         name =
@@ -461,14 +438,23 @@ defmodule Req.Finch do
                {Finch, name: name, pools: %{default: pool_options}}
              ) do
           {:ok, _} ->
-            name
+            {name, []}
 
           {:error, {:already_started, _}} ->
-            name
+            {name, []}
         end
 
-      true ->
-        Req.Finch
+      nil ->
+        {Req.Finch, []}
+
+      _ when is_map_key(request.options, :connect_options) ->
+        raise ArgumentError, "cannot set both :finch and :connect_options"
+
+      name when is_atom(name) ->
+        {name, []}
+
+      {name, options} when is_atom(name) ->
+        {name, Keyword.validate!(options, [:pool_tag])}
     end
   end
 

--- a/lib/req/finch.ex
+++ b/lib/req/finch.ex
@@ -76,10 +76,7 @@ defmodule Req.Finch do
           {:stream, enumerable}
       end
 
-    build_opts =
-      request.options
-      |> Map.take([:unix_socket, :pool_tag])
-      |> Enum.to_list()
+    build_opts = finch_build_opts(request)
 
     finch_request =
       Finch.build(request.method, request.url, request_headers, body, build_opts)
@@ -415,16 +412,37 @@ defmodule Req.Finch do
     end
   end
 
+  defp finch_build_opts(request) do
+    pool_tag_opts =
+      case request.options[:finch] do
+        {_name, opts} when is_list(opts) ->
+          Keyword.take(opts, [:pool_tag])
+
+        _ ->
+          []
+      end
+
+    unix_socket_opts =
+      request.options
+      |> Map.take([:unix_socket])
+      |> Enum.to_list()
+
+    pool_tag_opts ++ unix_socket_opts
+  end
+
   defp finch_name(request) do
     custom_options? =
       Map.has_key?(request.options, :connect_options) or Map.has_key?(request.options, :inet6)
 
     cond do
-      name = request.options[:finch] ->
+      finch_opt = request.options[:finch] ->
         if Map.has_key?(request.options, :connect_options) do
           raise ArgumentError, "cannot set both :finch and :connect_options"
-        else
-          name
+        end
+
+        case finch_opt do
+          {name, _opts} -> name
+          name -> name
         end
 
       custom_options? ->

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -62,7 +62,6 @@ defmodule Req.Steps do
       :receive_timeout,
       :pool_timeout,
       :unix_socket,
-      :pool_tag,
       :pool_max_idle_time,
 
       # TODO: Remove on Req 1.0
@@ -816,6 +815,16 @@ defmodule Req.Steps do
   ## Request Options
 
     * `:finch` - the name of the Finch pool. Defaults to a pool automatically started by Req.
+      Can be either a pool name (atom) or a `{name, opts}` tuple where `opts` can include:
+
+        * `:pool_tag` - the tag to use when selecting which Finch pool to use for a request.
+          Defaults to `:default`. This allows routing requests to different pools for the same
+          host. See `Finch.Pool.new/2` for more information on configuring tagged pools.
+
+      Examples:
+
+          Req.get!("https://api.example.com/data", finch: MyFinch)
+          Req.get!("https://api.example.com/data", finch: {MyFinch, pool_tag: :bulk})
 
     * `:connect_options` - dynamically starts (or re-uses already started) Finch pool with
       the given connection options:
@@ -852,10 +861,6 @@ defmodule Req.Steps do
       See `Finch.request/3`.
 
     * `:unix_socket` - if set, connect through the given UNIX domain socket.
-
-    * `:pool_tag` - the tag to use when selecting which Finch pool to use for a request.
-      Defaults to `:default`. This allows routing requests to different pools for the same
-      host. See `Finch.Pool.new/2` for more information on configuring tagged pools.
 
     * `:pool_max_idle_time` - the maximum number of milliseconds that a pool can be
       idle before being terminated, used only by HTTP1 pools. Default to `:infinity`.

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -817,9 +817,10 @@ defmodule Req.Steps do
     * `:finch` - the name of the Finch pool. Defaults to a pool automatically started by Req.
       Can be either a pool name (atom) or a `{name, opts}` tuple where `opts` can include:
 
-        * `:pool_tag` - the tag to use when selecting which Finch pool to use for a request.
-          Defaults to `:default`. This allows routing requests to different pools for the same
-          host. See `Finch.Pool.new/2` for more information on configuring tagged pools.
+        * `:pool_tag` - (requires Finch v0.22+) the tag to use when selecting which Finch pool to
+          use for a request. Defaults to `:default`. This allows routing requests to different
+          pools for the same host. See `Finch.Pool.new/2` for more information on configuring
+          tagged pools.
 
       Examples:
 

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -62,6 +62,7 @@ defmodule Req.Steps do
       :receive_timeout,
       :pool_timeout,
       :unix_socket,
+      :pool_tag,
       :pool_max_idle_time,
 
       # TODO: Remove on Req 1.0
@@ -851,6 +852,10 @@ defmodule Req.Steps do
       See `Finch.request/3`.
 
     * `:unix_socket` - if set, connect through the given UNIX domain socket.
+
+    * `:pool_tag` - the tag to use when selecting which Finch pool to use for a request.
+      Defaults to `:default`. This allows routing requests to different pools for the same
+      host. See `Finch.Pool.new/2` for more information on configuring tagged pools.
 
     * `:pool_max_idle_time` - the maximum number of milliseconds that a pool can be
       idle before being terminated, used only by HTTP1 pools. Default to `:infinity`.

--- a/test/req/finch_test.exs
+++ b/test/req/finch_test.exs
@@ -651,40 +651,28 @@ defmodule Req.FinchTest do
                ]
     end
 
-    test ":pool_tag is forwarded to Finch request" do
-      %{url: url} =
-        start_http_server(fn conn ->
-          Plug.Conn.send_resp(conn, 200, "ok")
-        end)
-
-      pid = self()
-
-      fun = fn req, finch_request, finch_name, finch_opts ->
-        send(pid, {:pool_tag, finch_request.pool_tag})
-        {:ok, resp} = Finch.request(finch_request, finch_name, finch_opts)
-        {req, Req.Response.new(status: resp.status, headers: resp.headers, body: resp.body)}
+    def send_pool_tag(_name, _measurements, metadata, _config) do
+      if pid = metadata.request.private[:pid] do
+        send(pid, {:pool_tag, metadata.request.pool_tag})
       end
 
-      assert Req.get!(url, finch_request: fun, finch: {Req.Finch, pool_tag: :bulk}).body == "ok"
-      assert_received {:pool_tag, :bulk}
+      :ok
     end
 
-    test ":pool_tag defaults to :default" do
+    test ":finch {name, pool_tag: tag} sets the request's pool_tag", %{test: test} do
+      on_exit(fn -> :telemetry.detach("#{test}") end)
+
+      :telemetry.attach("#{test}", [:finch, :request, :stop], &__MODULE__.send_pool_tag/4, nil)
+
       %{url: url} =
         start_http_server(fn conn ->
           Plug.Conn.send_resp(conn, 200, "ok")
         end)
 
-      pid = self()
+      assert Req.get!(url, finch: {Req.Finch, pool_tag: :bulk}, finch_private: %{pid: self()}).body ==
+               "ok"
 
-      fun = fn req, finch_request, finch_name, finch_opts ->
-        send(pid, {:pool_tag, finch_request.pool_tag})
-        {:ok, resp} = Finch.request(finch_request, finch_name, finch_opts)
-        {req, Req.Response.new(status: resp.status, headers: resp.headers, body: resp.body)}
-      end
-
-      assert Req.get!(url, finch_request: fun).body == "ok"
-      assert_received {:pool_tag, :default}
+      assert_received {:pool_tag, :bulk}
     end
   end
 end

--- a/test/req/finch_test.exs
+++ b/test/req/finch_test.exs
@@ -665,7 +665,7 @@ defmodule Req.FinchTest do
         {req, Req.Response.new(status: resp.status, headers: resp.headers, body: resp.body)}
       end
 
-      assert Req.get!(url, finch_request: fun, pool_tag: :bulk).body == "ok"
+      assert Req.get!(url, finch_request: fun, finch: {Req.Finch, pool_tag: :bulk}).body == "ok"
       assert_received {:pool_tag, :bulk}
     end
 

--- a/test/req/finch_test.exs
+++ b/test/req/finch_test.exs
@@ -650,5 +650,41 @@ defmodule Req.FinchTest do
                  conn_opts: [transport_opts: [timeout: 0, inet6: true, cacerts: []]]
                ]
     end
+
+    test ":pool_tag is forwarded to Finch request" do
+      %{url: url} =
+        start_http_server(fn conn ->
+          Plug.Conn.send_resp(conn, 200, "ok")
+        end)
+
+      pid = self()
+
+      fun = fn req, finch_request, finch_name, finch_opts ->
+        send(pid, {:pool_tag, finch_request.pool_tag})
+        {:ok, resp} = Finch.request(finch_request, finch_name, finch_opts)
+        {req, Req.Response.new(status: resp.status, headers: resp.headers, body: resp.body)}
+      end
+
+      assert Req.get!(url, finch_request: fun, pool_tag: :bulk).body == "ok"
+      assert_received {:pool_tag, :bulk}
+    end
+
+    test ":pool_tag defaults to :default" do
+      %{url: url} =
+        start_http_server(fn conn ->
+          Plug.Conn.send_resp(conn, 200, "ok")
+        end)
+
+      pid = self()
+
+      fun = fn req, finch_request, finch_name, finch_opts ->
+        send(pid, {:pool_tag, finch_request.pool_tag})
+        {:ok, resp} = Finch.request(finch_request, finch_name, finch_opts)
+        {req, Req.Response.new(status: resp.status, headers: resp.headers, body: resp.body)}
+      end
+
+      assert Req.get!(url, finch_request: fun).body == "ok"
+      assert_received {:pool_tag, :default}
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Extend the `:finch` option to accept a `{name, opts}` tuple, allowing users to pass `:pool_tag` and `:unix_socket` directly to `Finch.build/5`.
- Refactor `Finch.build` call to use the 5th `opts` argument, replacing the previous `Map.replace!/2` mutation pattern.

## Motivation

Finch supports configuring multiple connection pools for the same endpoint, differentiated by a tag via `Finch.Pool.new/2`. This is useful for separating traffic by purpose (e.g., bulk ingestion vs. real-time queries) with different pool sizes and concurrency settings. Previously, there was no way to leverage this feature through Req without resorting to the low-level `:finch_request` callback.

As [suggested by @jswanner](https://github.com/wojtekmach/req/pull/539#issuecomment-4346326767), since `:pool_tag` and `:unix_socket` are only relevant when using your own Finch name, they are nested under the `:finch` option rather than exposed as top-level Req options. This also means future `Finch.build/5` options won't require Req changes to support.

## Usage

```elixir
# Configure Finch with tagged pools
children = [
  {Finch,
   name: MyFinch,
   pools: %{
     Finch.Pool.new("https://api.example.com") => [size: 50, count: 4],
     Finch.Pool.new("https://api.example.com", tag: :bulk) => [size: 100, count: 1]
   }}
]

# Route a request to the :bulk pool
Req.get!("https://api.example.com/data", finch: {MyFinch, pool_tag: :bulk})

# Connect via UNIX socket
Req.get!("http:///v1.41/_ping", finch: {MyFinch, unix_socket: "/var/run/docker.sock"})

# Plain name still works as before
Req.get!("https://api.example.com/data", finch: MyFinch)
```

## Changes

| File | Change |
|------|--------|
| `lib/req/finch.ex` | Add `finch_build_opts/1` to extract opts from `{name, opts}` tuple; update `finch_name/1` to handle tuple form |
| `lib/req/steps.ex` | Update `run_finch/1` docs to document the tuple API |
| `lib/req.ex` | Update `Req.new/1` docs for the `:finch` option |
| `test/req/finch_test.exs` | Tests using `finch: {Req.Finch, pool_tag: :bulk}` |

## Backward Compatibility

Fully backward compatible. The `:finch` option continues to accept a plain atom name. The `:unix_socket` top-level option still works when not using the tuple form. When `:pool_tag` is not specified, `Finch.build/5` defaults it to `:default`.