### PR TITLE
Warn and strip userinfo if present in url

### DIFF
--- a/lib/req.ex
+++ b/lib/req.ex
@@ -149,6 +149,7 @@ defmodule Req do
   > For interopability with those, use
   > `Req.get_headers_list/1`.
   """
+  require Logger
 
   # Response streaming to caller:
   #
@@ -599,7 +600,7 @@ defmodule Req do
     request =
       Enum.reduce(request_options, request, fn
         {:url, url}, acc ->
-          put_in(acc.url, URI.parse(url))
+          put_in(acc.url, parse_url(url))
 
         {:headers, new_headers}, acc ->
           update_in(acc.headers, &Req.Fields.merge(&1, new_headers))
@@ -621,6 +622,24 @@ defmodule Req do
           new
       end)
     )
+  end
+
+  defp parse_url(url) do
+    url = URI.parse(url)
+
+    if url.userinfo do
+      Logger.warning("""
+      non-empty url userinfo will be ignored.
+
+      To use basic auth, use the :auth step:
+
+         auth: {:basic, "user:password"}
+      """)
+
+      %{url | userinfo: nil}
+    else
+      url
+    end
   end
 
   @doc """

--- a/test/req_test.exs
+++ b/test/req_test.exs
@@ -65,6 +65,26 @@ defmodule ReqTest do
     assert headers == [{"x-a", "2"}, {"x-b", "1"}]
   end
 
+  test "warns and strips userinfo when set", c do
+    Bypass.expect(c.bypass, "GET", "/", fn conn ->
+      [user_agent] = Plug.Conn.get_req_header(conn, "user-agent")
+      Plug.Conn.send_resp(conn, 200, user_agent)
+    end)
+
+    url = String.replace(c.url, "http://", "http://foo:bar@")
+
+    assert ExUnit.CaptureLog.capture_log(fn ->
+             req = Req.new(url: url)
+
+             # userinfo has been stripped
+             refute inspect(req) =~ "foo:bar@"
+             assert inspect(req) =~ c.url
+
+             # request is sent without userinfo
+             assert Req.get!(req).status == 200
+           end) =~ "[warning] non-empty url userinfo will be ignored"
+  end
+
   test "redact" do
     assert inspect(Req.new(auth: {:bearer, "foo"})) =~ ~s|auth: {:bearer, "***"}|
 


### PR DESCRIPTION
Currently, when an URL with a `userinfo` like `Req.get!("https://foo:bar@httpbin.org/basic-auth/foo/bar")` is provided, `Req` silently ignores the userinfo, which makes it non-obvious why the request returns a 401:

It is especially confusing since `req.url` is still showed with the userinfo, and it can take some time to figure out when migrating an existing project from a library that used to handle the userinfo.

This PR adds a warning to shorten the feedback loop and provide actionable steps to address the issue.
We could probably be raising here, I went with a warning to be more conservative and kept the existing behavior - happy to update the strategy if we want to handle it differently.

<img width="954" height="730" alt="Screenshot 2026-04-25 at 17 03 51" src="https://github.com/user-attachments/assets/a474a326-cf25-4bda-9a2e-4f4c8f0dff19" />