### PR TITLE
Normalize Finch.TransportError and Finch.HTTPError (Finch 0.22+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+  * [`run_finch`]: Normalize `Finch.TransportError` and `Finch.HTTPError`
+    (introduced in Finch v0.22.0) into `Req.TransportError` and `Req.HTTPError`,
+    matching the existing handling of `Mint.TransportError` / `Mint.HTTPError`.
+
 ## v0.5.17 (2026-01-22)
 
   * [`retry`]: Use default delay if `retry-after` is "negative"

--- a/lib/req/finch.ex
+++ b/lib/req/finch.ex
@@ -215,6 +215,9 @@ defmodule Req.Finch do
     %Req.HTTPError{protocol: :http2, reason: reason}
   end
 
+  # TODO: When using finch ~> 0.22.0, convert to pattern matching
+  # and revisit explicitly handling Mint errors.
+  #
   # Finch >= 0.22 wraps Mint errors in its own structs. Use `is_struct/2` so
   # this still compiles against older Finch versions where these modules don't exist.
   defp normalize_error(error) when is_struct(error, Finch.TransportError) do

--- a/lib/req/finch.ex
+++ b/lib/req/finch.ex
@@ -215,6 +215,17 @@ defmodule Req.Finch do
     %Req.HTTPError{protocol: :http2, reason: reason}
   end
 
+  # Finch >= 0.22 wraps Mint errors in its own structs. Use `is_struct/2` so
+  # this still compiles against older Finch versions where these modules don't exist.
+  defp normalize_error(error) when is_struct(error, Finch.TransportError) do
+    %Req.TransportError{reason: error.reason}
+  end
+
+  defp normalize_error(error) when is_struct(error, Finch.HTTPError) do
+    protocol = if error.module == Mint.HTTP2, do: :http2, else: :http1
+    %Req.HTTPError{protocol: protocol, reason: error.reason}
+  end
+
   defp normalize_error(error) do
     error
   end

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule Req.MixProject do
 
   defp deps do
     [
-      {:finch, "~> 0.21.0", finch_opts()},
+      {:finch, "~> 0.21 or ~> 0.22", finch_opts()},
       {:mime, "~> 2.0.6 or ~> 2.1"},
       {:jason, "~> 1.0"},
       {:nimble_csv, "~> 1.0", optional: true},

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule Req.MixProject do
 
   defp deps do
     [
-      {:finch, "~> 0.21 or ~> 0.22", finch_opts()},
+      {:finch, "~> 0.21.0 or ~> 0.22.0", finch_opts()},
       {:mime, "~> 2.0.6 or ~> 2.1"},
       {:jason, "~> 1.0"},
       {:nimble_csv, "~> 1.0", optional: true},


### PR DESCRIPTION
## Summary

Finch v0.22.0 ([sneako/finch#341](https://github.com/sneako/finch/pull/341)) standardized error handling by introducing `Finch.TransportError` and `Finch.HTTPError` wrapper structs over the underlying `Mint.TransportError` / `Mint.HTTPError`.

`Req.Finch.normalize_error/1` currently only handles the bare `Mint.*` and `Finch.Error` forms, so the new wrapper structs fall through to the catch-all and leak to callers. The documented contract of `Req.Steps.run_finch/1` — that callers see `%Req.TransportError{}` / `%Req.HTTPError{}` — is broken on Finch 0.22.

This PR adds two clauses to `normalize_error/1` for the new structs and widens the Finch dep constraint to allow 0.22.

## Why `is_struct/2` instead of struct patterns

`Finch.TransportError` and `Finch.HTTPError` only exist in Finch ≥ 0.22. Using `is_struct(error, Finch.TransportError)` as a guard lets the new clauses compile cleanly against older Finch versions (where struct patterns `%Finch.TransportError{}` would error at compile time). Once the floor is bumped to `~> 0.22`, the clauses can be rewritten as direct struct matches.

## Verification

Existing connection-refused tests at `test/req/finch_test.exs:419` and `:488` already cover this contract. On Finch 0.22, they fail without this patch:

```
left:  {:error, %Req.TransportError{reason: :econnrefused}}
right: {:error,
        %Finch.TransportError{
          reason: :econnrefused,
          source: %Mint.TransportError{reason: :econnrefused}
        }}
```

…and pass with it.

Full suite on Finch 0.22.0: only one unrelated pre-existing failure remains — `test :connect_options :protocol` returns `%Req.HTTPError{protocol: :http2, reason: :pool_not_available}` due to Finch 0.22's new "Register only ready HTTP/2 connections" behavior ([sneako/finch#356](https://github.com/sneako/finch/pull/356)). That's a separate concern; this PR is scoped to error normalization.

## Test plan

- [x] `mix test test/req/finch_test.exs:419 test/req/finch_test.exs:488` passes on Finch 0.22.0
- [x] Reverting just the `normalize_error/1` clauses reproduces the failures
- [x] `mix compile` clean against Finch 0.21 (clauses are guarded by `is_struct/2`)
- [x] CHANGELOG entry added under `Unreleased`