### PR TITLE
Exclude accept-encoding and hop-by-hop headers from aws_sigv4 signature

### DIFF
--- a/lib/req/fields.ex
+++ b/lib/req/fields.ex
@@ -214,6 +214,29 @@ defmodule Req.Fields do
   end
 
   @doc """
+  Drops the given `names`.
+  """
+  if @legacy? do
+    def drop(fields, names) when is_binary(name) do
+      names_to_drop = Enum.map(names, &ensure_name_downcase/1)
+
+      for {name, value} <- fields,
+          name not in names_to_drop do
+        {name, value}
+      end
+    end
+  else
+    def drop(fields, names) do
+      names_to_drop = Enum.map(names, &ensure_name_downcase/1)
+
+      for {name, values} <- fields,
+          name not in names_to_drop do
+        {name, values}
+      end
+    end
+  end
+
+  @doc """
   Returns fields as list.
   """
   def get_list(fields)

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1477,12 +1477,7 @@ defmodule Req.Steps do
         end
 
       request = Req.Request.put_new_header(request, "host", request.url.host)
-
-      headers =
-        for {name, values} <- request.headers,
-            String.downcase(name) not in @aws_sigv4_excluded_headers,
-            value <- values,
-            do: {name, value}
+      headers = Req.Fields.drop(request.headers, @aws_sigv4_excluded_headers)
 
       headers =
         Req.Utils.aws_sigv4_headers(

--- a/lib/req/steps.ex
+++ b/lib/req/steps.ex
@@ -1357,6 +1357,27 @@ defmodule Req.Steps do
   defp hash_init(:sha1), do: hash_init(:sha)
   defp hash_init(type), do: :crypto.hash_init(type)
 
+  @aws_sigv4_excluded_headers [
+    # Services like R2 can rewrite this header when
+    # encodings it doesn't support are included, i.e. zstd
+    "accept-encoding",
+    # Trace ID can be rewritten by AWS infrastructure
+    "x-amzn-trace-id",
+    # Authorization is set by SigV4 itself / not part of canonical request
+    "authorization",
+    # RFC 2616 Section 13.5.1 "hop-by-hop" headers
+    # (list is historical; RFC 7230/9110 use Connection header as the
+    # authoritative mechanism, but this enumeration remains the practical baseline)
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade"
+  ]
+
   @doc """
   Signs request with AWS Signature Version 4.
 
@@ -1457,7 +1478,11 @@ defmodule Req.Steps do
 
       request = Req.Request.put_new_header(request, "host", request.url.host)
 
-      headers = for {name, values} <- request.headers, value <- values, do: {name, value}
+      headers =
+        for {name, values} <- request.headers,
+            String.downcase(name) not in @aws_sigv4_excluded_headers,
+            value <- values,
+            do: {name, value}
 
       headers =
         Req.Utils.aws_sigv4_headers(

--- a/test/req/steps_test.exs
+++ b/test/req/steps_test.exs
@@ -899,6 +899,70 @@ defmodule Req.StepsTest do
       assert Req.put!(req).body == "ok"
     end
 
+    test "excludes accept-encoding, hop-by-hop, and trace-id headers from signature" do
+      plug = fn conn ->
+        [authorization] = Plug.Conn.get_req_header(conn, "authorization")
+
+        signed_headers =
+          authorization
+          |> String.split(",")
+          |> Enum.find_value(fn part ->
+            case String.split(part, "=", parts: 2) do
+              ["SignedHeaders", value] -> String.split(value, ";")
+              _ -> nil
+            end
+          end)
+
+        for excluded <- [
+              "accept-encoding",
+              "x-amzn-trace-id",
+              "connection",
+              "keep-alive",
+              "proxy-authenticate",
+              "proxy-authorization",
+              "te",
+              "trailer",
+              "transfer-encoding",
+              "upgrade"
+            ] do
+          refute excluded in signed_headers,
+                 "expected #{excluded} not in SignedHeaders, got: #{inspect(signed_headers)}"
+        end
+
+        # Headers excluded from the signature are still sent on the wire.
+        assert ["zstd, br, gzip"] = Plug.Conn.get_req_header(conn, "accept-encoding")
+        assert ["trace-123"] = Plug.Conn.get_req_header(conn, "x-amzn-trace-id")
+        assert ["keep-alive"] = Plug.Conn.get_req_header(conn, "connection")
+
+        # Non-excluded custom headers are still signed.
+        assert "x-custom" in signed_headers
+
+        Plug.Conn.send_resp(conn, 200, "ok")
+      end
+
+      req =
+        Req.new(
+          url: "https://s3.amazonaws.com",
+          aws_sigv4: [access_key_id: "foo", secret_access_key: "bar"],
+          headers: [
+            "x-amzn-trace-id": "trace-123",
+            connection: "keep-alive",
+            "keep-alive": "timeout=5",
+            "proxy-authenticate": "Basic",
+            "proxy-authorization": "Basic foo",
+            te: "trailers",
+            trailer: "Expires",
+            "transfer-encoding": "chunked",
+            upgrade: "websocket",
+            "x-custom": "signed"
+          ],
+          body: "hello",
+          plug: plug
+        )
+
+      assert Req.put!(req).body == "ok"
+    end
+
     test "missing :access_key_id" do
       req = Req.new(aws_sigv4: [])
 


### PR DESCRIPTION
## Summary

Hello! This change came out of a production incident we had last night where our signed Cloudflare R2 requests began to fail with 403 responses after a deployment.

We tracked the bug to the introduction of `ezstd` in our code base for a separate feature:

1. When `ezstd` is installed, `req` adds `zstd` to the `Accept-Encoding` header provided by `Req.Steps.compressed/1`
2. `Accept-Encoding` header is included in the signature, and included in the authorization field `SignedHeaders`
3. Cloudflare R2 rewrites this header to `Accept-Encoding: gzip` on the edge, breaking the signature

After looking into other libraries that implement this auth mechanism e.g. boto3, we discovered that they have a list of headers they exclude from the signature. 

- RFC 2616 Sect 13.5.1 "hop-by-hop" headers
- `x-amzn-trace-id` which can be rewritten by AWS ALBs
- Other library-specific headers that don't apply in the context of Req

## Changes

- Add a list of headers to exclude when running the `aws_sigv4` step:
  - RFC 2616 hop-by-hop headers
  - `x-amzn-trace-id` -- can be rewritten by AWS infrastructure
  - `authorization` -- `aws_sigv4` creates this so it is not part of the canonical request
  - `accept-encoding` -- excluded because it is commonly rewritten by edge proxies
- Update unit tests

## Alternatives Considered

I had considered moving the `Req.Steps.compressed/1` step after `Req.Steps.put_aws_sigv4`, rejected since user-supplied `accept-encoding` would still get signed and hit the same bug. Additionally this change is more brittle since re-ordering this step could have other effects I'm not considering. Not reordering the steps keeps a clean mental model of "signature as the last step".

## Steps to Reproduce

To reproduce the bug is straightforward:

1. Create a mix project with ezstd and req installed

```elixir
  defp deps do
    [
      {:req, "~> 0.5.18"},
      {:ezstd, "~> 1.2"}
    ]
  end
```

2. Make a request to a Cloudflare R2 bucket using `aws_sigv4`, observe 403.

```elixir
Req.head(
  "https://#{@account_id}.r2.cloudflarestorage.com/#{@bucket}/#{@key}",
  aws_sigv4: [
    access_key_id: @access_key_id,
    secret_access_key: @secret_access_key,
    service: :s3,
    region: "auto"
  ]
)
{:ok,
 %Req.Response{
   status: 403,
   headers: %{...},
   body: "",
   trailers: %{},
   assigns: %{},
   private: %{}
 }}
```

3. Include `compressed: false` on the request and observe 200

```elixir
Req.head(
  "https://#{@account_id}.r2.cloudflarestorage.com/#{@bucket}/#{@key}",
  compressed: false,
  aws_sigv4: [
    access_key_id: @access_key_id,
    secret_access_key: @secret_access_key,
    service: :s3,
    region: "auto"
  ]
)
{:ok,
 %Req.Response{
   status: 200,
   headers: %{...},
   body: "",
   trailers: %{},
   assigns: %{},
   private: %{}
 }}
```

4. Remove ezstd, re-install deps, and perform the same request without `compressed: false`. Observe 200 response.

```elixir
Req.head(
  "https://#{@account_id}.r2.cloudflarestorage.com/#{@bucket}/#{@key}",
  aws_sigv4: [
    access_key_id: @access_key_id,
    secret_access_key: @secret_access_key,
    service: :s3,
    region: "auto"
  ]
)
{:ok,
 %Req.Response{
   status: 200,
   headers: %{...},
   body: "",
   trailers: %{},
   assigns: %{},
   private: %{}
 }}
```
