### PR TITLE
Allow finch 0.23.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -90,7 +90,7 @@ defmodule Req.MixProject do
 
   defp deps do
     [
-      {:finch, "~> 0.21.0 or ~> 0.22.0", finch_opts()},
+      {:finch, "~> 0.21.0 or ~> 0.22.0 or ~> 0.23.0", finch_opts()},
       {:mime, "~> 2.0.6 or ~> 2.1"},
       {:jason, "~> 1.0"},
       {:nimble_csv, "~> 1.0", optional: true},


### PR DESCRIPTION
Finch 0.23.0 has been released and fixes https://github.com/sneako/finch/issues/375, but `Req` currently doesn't allow it.

I'm not sure that the approach scales, perhaps we should just go back to `"~> 0.21"`.