### PR TITLE
Reference req_server_sent_events plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ There are many packages that extend the Req library. To get yours listed here, s
   * [`http_cookie`]
   * [`req_embed`]
   * [`req_proxy`]
+  * [`req_server_sent_events`]
 
 ## Presentations
 
@@ -291,3 +292,4 @@ limitations under the License.
 [`http_cookie`]: https://github.com/reisub/http_cookie
 [`req_embed`]: https://github.com/leandrocp/req_embed
 [`req_proxy`]: https://gitlab.com/wmde/technical-wishes/req_proxy
+[`req_server_sent_events`]: https://github.com/sgerrand/ex_req_server_sent_events

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ There are many packages that extend the Req library. To get yours listed here, s
   * [`http_cookie`]
   * [`req_embed`]
   * [`req_proxy`]
-  * [`req_server_sent_events`]
+  * [`req_server_sent_events`] (supports SSE with `into: collectable | :self`)
 
 ## Presentations
 


### PR DESCRIPTION
💁 This change adds a reference to the [req_server_sent_events](https://github.com/sgerrand/ex_req_server_sent_events) plugin, which decodes chunked SSE byte streams into structs, transparently wrapping all three of Req's streaming hooks: `into: fun`, `into: :self`, and `into: collectable`. I wrote it to make this process easier for myself and hopefully should do the same for others.